### PR TITLE
Interpolation (WIP)

### DIFF
--- a/Applications/FunctionBasedPathConversion/CMakeLists.txt
+++ b/Applications/FunctionBasedPathConversion/CMakeLists.txt
@@ -5,6 +5,3 @@ endif()
 if(BUILD_TESTING)
     subdirs(test)
 endif(BUILD_TESTING)
-
-
-

--- a/Applications/FunctionBasedPathConversion/test/testFunctionBasedPathConversion.cpp
+++ b/Applications/FunctionBasedPathConversion/test/testFunctionBasedPathConversion.cpp
@@ -142,7 +142,7 @@ void testArmModelConversionAccuracy() {
 
         long millis = static_cast<long>(std::chrono::duration_cast<std::chrono::milliseconds>(ts.simTime).count());
 
-        printf("%s: \n    avg. time (ms) = %ld \n    integration steps attempted = %i \n    integration steps taken = %i)",
+        printf("%s: \n    avg. time (ms) = %ld \n    integration steps attempted = %i \n    integration steps taken = %i)\n",
                ts.name.c_str(),
                millis,
                ts.stepsAttempted,

--- a/Applications/FunctionBasedPathConversion/test/testFunctionBasedPathConversion.cpp
+++ b/Applications/FunctionBasedPathConversion/test/testFunctionBasedPathConversion.cpp
@@ -38,17 +38,165 @@
 
 using namespace OpenSim;
 
-void testArmModelConversionAccuracy() {
+// output reporter that just appends some double output to an output vector
+class VectorReporter final : public AbstractReporter {
+public:
+    struct Datapoint { double time; double v; };
+private:
+    const Output<double>& m_Source;
+    std::vector<Datapoint>& m_Sink;
+
+public:
+    VectorReporter(const Output<double>& source,
+                   std::vector<Datapoint>& sink) :
+        AbstractReporter{},
+        m_Source{source},
+        m_Sink{sink}
+    {
+    }
+
+    void implementReport(const SimTK::State& s) const override {
+        double t = s.getTime();
+        double v = m_Source.getValue(s);
+
+        m_Sink.push_back(Datapoint{t, v});
+    }
+
+    VectorReporter* clone() const override {
+        return new VectorReporter{*this};
+    }
+
+    const std::string& getConcreteClassName() const override {
+        static std::string name = "VectorReporter";
+        return name;
+    }
+};
+
+static void testLengthDifferenceBetweenFBPAndPBPIsSmall() {
     std::string inputModelPath = "arm26.osim";
-    std::string outputModelName = "arm26_FBP";
+    std::string outputModelName = "arm26_FBP.osim";
+    std::string force = "/forceset/TRIlong";
+    std::string output = "length";
+    double reportingInterval = 0.05;
+    int discretizationPoints = 80;
+
+    FunctionBasedPathConversionTool tool{inputModelPath, outputModelName};
+    auto params = tool.getFittingParams();
+    params.numDiscretizationStepsPerDimension = discretizationPoints;
+    tool.setFittingParams(params);
+    tool.setVerbose(true);
+    tool.run();
+
+    // load + init both models
+    Model inputModel{inputModelPath};
+    inputModel.finalizeConnections();
+    inputModel.finalizeFromProperties();
+    inputModel.initSystem();
+
+    Model outputModel{outputModelName};
+    outputModel.finalizeConnections();
+    outputModel.finalizeFromProperties();
+    outputModel.initSystem();
+
+    // connect input model's force output to a vector that records the data
+    std::vector<VectorReporter::Datapoint> pbpDatapoints;
+    {
+        const AbstractOutput& ao = inputModel.getComponent(force + "/pointbasedpath").getOutput(output);
+        const Output<double>* o = dynamic_cast<const Output<double>*>(&ao);
+        if (!o) {
+            throw std::runtime_error{"Input model output is not of `double` type"};
+        }
+        auto reporter = std::unique_ptr<VectorReporter>(new VectorReporter{*o, pbpDatapoints});
+        reporter->set_report_time_interval(reportingInterval);
+        inputModel.addComponent(reporter.release());
+    }
+
+    // connect output model's force output to a vector that records the data
+    std::vector<VectorReporter::Datapoint> fbpDatapoints;
+    {
+        const AbstractOutput& ao = outputModel.getComponent(force + "/functionbasedpath").getOutput(output);
+        const Output<double>* o = dynamic_cast<const Output<double>*>(&ao);
+        if (!o) {
+            throw std::runtime_error{"Input model output is not of `double` type"};
+        }
+        auto reporter = std::unique_ptr<VectorReporter>(new VectorReporter{*o, fbpDatapoints});
+        reporter->set_report_time_interval(reportingInterval);
+        outputModel.addComponent(reporter.release());
+    }
+
+    // init initial system + states
+    double finalSimTime = 3.5;
+
+    // run FD sim of PBP
+    {
+        SimTK::State& inputModelState = inputModel.initSystem();
+        OpenSim::Manager manager{inputModel};
+        manager.initialize(inputModelState);
+        manager.integrate(finalSimTime);
+    }
+
+    // run FD sim of FBP
+    {
+        SimTK::State& outputModelState = outputModel.initSystem();
+        OpenSim::Manager manager{outputModel};
+        manager.initialize(outputModelState);
+        manager.integrate(finalSimTime);
+    }
+
+    // validate API assumptions
+    size_t expectedSteps = static_cast<size_t>(finalSimTime / reportingInterval);
+    {
+        OPENSIM_THROW_IF(pbpDatapoints.empty(), OpenSim::Exception, "pbpDatapoints empty: is it connected to the model?");
+        OPENSIM_THROW_IF(fbpDatapoints.empty(), OpenSim::Exception, "fbpDatapoints empty: is it connected to the model?");
+        OPENSIM_THROW_IF(pbpDatapoints.size() == expectedSteps, OpenSim::Exception, "pbpDatapoints has incorrect number of datapoints");
+        OPENSIM_THROW_IF(fbpDatapoints.size() == expectedSteps, OpenSim::Exception, "fbpDatapoints has incorrect number of datapoints");
+
+        for (size_t i = 0; i < expectedSteps; ++i) {
+            double pbpT = pbpDatapoints[i].time;
+            double fbpT = fbpDatapoints[i].time;
+            OPENSIM_THROW_IF(!SimTK::isNumericallyEqual(pbpT, fbpT), OpenSim::Exception, "timepoints in PBP and FBP arrays differ");
+        }
+    }
+
+    struct RelErrStats {
+        double min = std::numeric_limits<double>::max();
+        double max = std::numeric_limits<double>::min();
+        double avg = 0.0;
+        int n = 0;
+    };
+    RelErrStats stats;
+
+    std::cout << "t    \tpbp  \tfbp  \t%err \n";
+    for (size_t i = 0; i < expectedSteps; ++i) {
+        double t = pbpDatapoints[i].time;
+        double pbpV = pbpDatapoints[i].v;
+        double fbpV = fbpDatapoints[i].v;
+        double relErr = (fbpV-pbpV)/pbpV;
+        double relPctErr = 100.0 * relErr;
+
+        stats.min = std::min(stats.min, relErr);
+        stats.max = std::max(stats.max, relErr);
+        stats.avg = std::fma(stats.avg, stats.n, relErr) / (stats.n+1);
+        stats.n += 1;
+
+        std::cout << std::fixed << std::setprecision(5) << t << '\t' << pbpV << '\t' << fbpV << '\t' << relPctErr << " %\n";
+    }
+
+    std::cout << "min = " << 100.0*stats.min << " %, max = " << 100.0*stats.max << " %, avg = " << 100.0*stats.avg << " %\n";
+}
+
+static void testArmModelConversionAccuracy() {
+    std::string inputModelPath = "arm26.osim";
+    std::string outputModelName = "arm26_FBP.osim";
 
     // run the function-based path (FBP) conversion tool to create an FBP-based output
     FunctionBasedPathConversionTool tool{inputModelPath, outputModelName};
+    tool.setVerbose(true);
     tool.run();
 
     // load both the input and output into memory
     Model inputModel{inputModelPath};
-    Model outputModel{outputModelName + ".osim"};
+    Model outputModel{outputModelName};
 
     // init the input model
     inputModel.finalizeConnections();
@@ -71,7 +219,7 @@ void testArmModelConversionAccuracy() {
     std::string output = "length";
 
     // connect reporter to input model
-    {
+    if (true) {
         auto inputModelReporter = std::unique_ptr<ConsoleReporter>{new ConsoleReporter{}};
         inputModelReporter->setName("point_results");
         inputModelReporter->set_report_time_interval(0.05);
@@ -80,7 +228,7 @@ void testArmModelConversionAccuracy() {
     }
 
     // connect reporter to output model
-    {
+    if (true) {
         auto outputModelReporter = std::unique_ptr<ConsoleReporter>{new ConsoleReporter{}};
         outputModelReporter ->setName("function_results");
         outputModelReporter ->set_report_time_interval(0.05);
@@ -153,6 +301,7 @@ void testArmModelConversionAccuracy() {
 int main() {
     try {
         SimTK_START_TEST("testFunctionBasedPathConversion");
+            SimTK_SUBTEST(testLengthDifferenceBetweenFBPAndPBPIsSmall);
             SimTK_SUBTEST(testArmModelConversionAccuracy);
         SimTK_END_TEST();
     } catch (const std::exception& ex) {

--- a/OpenSim/Simulation/Model/FunctionBasedPath.cpp
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.cpp
@@ -1,66 +1,35 @@
-#include "GeometryPath.h"
-#include "ConditionalPathPoint.h"
 #include "FunctionBasedPath.h"
-#include "MovingPathPoint.h"
-#include "PointForceDirection.h"
-#include <OpenSim/Simulation/Wrap/PathWrap.h>
 
-#include <OpenSim/Common/IO.h>
 #include <OpenSim/Simulation/Model/Model.h>
 #include <OpenSim/Simulation/Model/PointBasedPath.h>
 #include <OpenSim/Simulation/SimbodyEngine/Coordinate.h>
+#include <SimTKcommon/internal/State.h>
 
+#include <array>
+#include <memory>
 #include <vector>
-#include <iostream>
-#include <cmath>
-#include <random>
-#include <cmath>
-#include <algorithm>
-#include <numeric>
-#include <sstream>
 
-using namespace std;
-using namespace OpenSim;
-using namespace SimTK;
-using SimTK::Vec3;
+// upper limit on the number of coordinates that can be reasonably interpolated
+// the implementation
+//
+// interpolation can suffer from a combinatorial explosion. Even if you only discretize
+// two points per coordinate, 16 input coordinates can produce 2^16 discretizations
+static constexpr size_t g_MaxCoordsThatCanBeInterpolated = 16;
 
-template <typename T>
-void printVector(std::vector<T> vec){
-    std::cout << "vec["<<vec.size()<<"]: [";
-    for (unsigned i=0; i<vec.size(); i++){
-        std::cout << vec[i] << ",";
-    }
-    std::cout << "]" << std::endl;
-}
+// number of "probing" steps to take when trying to figure out whether a given coordinate
+// affects a point-based path
+static constexpr int g_NumCoordProbingSteps = 3;
 
-// defer an action until the destruction of this wrapper
-template<typename Callback>
-struct Defer final {
-    Callback cb;
-    Defer(Callback _cb) : cb{std::move(_cb)} {
-    }
-    Defer(Defer const&) = delete;
-    Defer(Defer&&) noexcept = default;
-    Defer& operator=(Defer const&) = delete;
-    Defer& operator=(Defer&&) = delete;
-    ~Defer() noexcept {
-        cb();
-    }
-};
-template<typename Callback>
-Defer<Callback> defer_action(Callback cb) {
-    return Defer<Callback>{std::move(cb)};
-}
+// the minimum amount a moment arm must change when probing for the probing step to return
+// `true` (i.e. "this coordinate does affect the path")
+static constexpr double g_MinMomentArmChangeRequiredForPositiveProbe = 0.001;
 
-// Returns `true` if changing the supplied `Coordinate` changes the moment arm
+// returns `true` if changing the supplied `Coordinate` changes the moment arm
 // of the supplied `PointBasedPath` (PBP)
-static bool coordinateAffectsPBP(
+static bool coordAffectsPBP(
     OpenSim::PointBasedPath const& pbp,
     OpenSim::Coordinate const& c,
     SimTK::State& state) {
-
-    static constexpr int numCoordProbingSteps = 3;
-    static constexpr double minMomentArmChangeRequired = 0.001;
 
     bool initialLockedState = c.getLocked(state);
     double initialValue = c.getValue(state);
@@ -69,14 +38,14 @@ static bool coordinateAffectsPBP(
 
     double start = c.getRangeMin();
     double end = c.getRangeMax();
-    double step = (end - start) / numCoordProbingSteps;
+    double step = (end - start) / g_NumCoordProbingSteps;
 
     bool affectsCoord = false;
     for (double v = start; v <= end; v += step) {
         c.setValue(state, v);
         double ma = pbp.computeMomentArm(state, c);
 
-        if (std::abs(ma) >= minMomentArmChangeRequired) {
+        if (std::abs(ma) >= g_MinMomentArmChangeRequiredForPositiveProbe) {
             affectsCoord = true;
             break;
         }
@@ -88,450 +57,475 @@ static bool coordinateAffectsPBP(
     return affectsCoord;
 }
 
-// Fills the output vector with n linearly-spaced values in the inclusive range
-// [begin, end]
-static void linspace(double begin,
-                     double end,
-                     size_t n,
-                     std::vector<double>& out) {
-    if (n == 0) {
-        return;
-    }
+// returns a sequence of `OpenSim::Coordinate`s that affect the supplied
+// point-based path (PBP)
+//
+// is not guaranteed to find *all* coordinates that affect the supplied PBP,
+// because that may involve extreme probing (which this implementation does not
+// do)
+static std::vector<OpenSim::Coordinate const*> coordsThatAffectPBP(OpenSim::Model const& model,
+                                                                   OpenSim::PointBasedPath const& pbp,
+                                                                   SimTK::State& st) {
+    std::vector<const OpenSim::Coordinate*> rv;
+    for (OpenSim::Coordinate const& c : model.getComponentList<OpenSim::Coordinate>()){
+        if (c.getMotionType() == OpenSim::Coordinate::MotionType::Coupled) {
+            continue;
+        }
 
-    if (n == 1) {
-        out.push_back(begin);
-        return;
-    }
+        if (!coordAffectsPBP(pbp, c, st)) {
+            continue;
+        }
 
-    double step = (end - begin) / (n-1);
-    for (size_t i = 0; i < n-1; ++i) {
-        out.push_back(begin + i*step);
+        rv.push_back(&c);
     }
-    out.push_back(end);
+    return rv;
 }
 
-// A discretization of n points along the (incluside) interval [begin, end]
+// discretization of a particular coordinate
+//
+// assumes `nsteps` evenly-spaced points ranging from [begin, end] (inclusive)
 struct Discretization final {
     double begin;
     double end;
-    int nPoints;
-    double gridsize;
+    int nsteps;
 };
 
-// overload for linspace that is specialized for `Discretization`s
-static void linspace(const Discretization& d, std::vector<double>& out) {
-    assert(d.nPoints >= 0);
+// compute ideal discretization of the given coordinate
+static Discretization discretizationForCoord(OpenSim::Coordinate const&) {
+    // TODO: these hacky ranges were imported from the original code. Joris had this
+    // commented out:
+    //     dc.begin = std::max(c.getRangeMin(), -static_cast<double>(SimTK_PI));
+    //     dc.end = std::min(c.getRangeMax(), static_cast<double>(SimTK_PI));
+    Discretization d;
+    d.begin = -static_cast<double>(SimTK_PI)/2;
+    d.end = static_cast<double>(SimTK_PI)/2;
+    d.nsteps = 80;
+    double step = (d.end-d.begin) / (d.nsteps-1);
 
-    out.clear();
-    linspace(d.begin, d.end, static_cast<size_t>(d.nPoints), out);
+    // expand range slightly in either direction to ensure interpolation is
+    // clean around the edges
+    d.begin -= step;
+    d.end += 2.0 * step;
+    d.nsteps += 3;
+
+    return d;
 }
 
-class Interpolate final {
-private:
-    // the dimensionality of the interpolation (i.e. a 2D fit == 2)
-    int dimensions;
+// compute all permutations of the coordinates for the given discretizations
+//
+// these output values are stored "lexographically", with coords being "big endian", so:
+//
+// - [coord[0].begin, coord[1].begin, ..., coord[n-1].begin]
+// - [coord[0].begin, coord[1].begin, ..., (coord[n-1].begin + step)]
+// - [coord[0].begin, coord[1].begin, ..., (coord[n-1].begin + 2*step)]
+// - ...
+// - [coord[0].begin, (coord[1].begin + step), ..., coord[n-1].begin]
+// - [coord[0].begin, (coord[1].begin + step), ..., (coord[n-1].begin + step)]
+// - ...
+// - [(coord[0].begin + step), coord[1].begin, ..., coord[n-1].begin]
+// - [(coord[0].begin + step), coord[1].begin, ..., (coord[n-1].begin + step)]
+static std::vector<double> computeEvaluationsFromPBP(OpenSim::PointBasedPath const& pbp,
+                                                    SimTK::State& state,
+                                                    OpenSim::Coordinate const** coords,
+                                                    Discretization const* discs,
+                                                    size_t ncoords) {
+    std::vector<double> rv;
 
-    // vector containing the orthogonal discretization vectors
-    // e.g. disc[0] = xrange, disc[1] = yrange etc.
-    std::vector<std::vector<double>> discretizations;
+    if (ncoords == 0) {  // edge-case: logic below assumes ncoords > 0
+        return rv;
+    }
 
-    std::vector<double> discSizes;
+    OPENSIM_THROW_IF(ncoords > g_MaxCoordsThatCanBeInterpolated, OpenSim::Exception, "too many coordinates affect this path - the FunctionBasedPath implementation cannot handle this");
 
-    // array containing the evaluations over the discretizations
-    std::vector<double> evals;
+    // number of evaluations is the total number of permutations of all dimensions for
+    // all discretizations
+    int expectedEvals = 1;
+    for (size_t i = 0; i < ncoords; ++i) {
+        expectedEvals *= discs[i].nsteps;
+    }
+    rv.reserve(expectedEvals);
 
-    // vector containing index closest to discretization point
-    std::vector<int> n;
+    // holds which "step" in each Coordinate's [begin, end] discretization we
+    // have evaluated up to
+    std::array<int, g_MaxCoordsThatCanBeInterpolated> discStepIdx{};
 
-    // vector containing fraction of closest index to discretization
-    // point to next
-    std::vector<double> u;
+    while (discStepIdx[0] < discs[0].nsteps) {
 
-    // array of polynomial evaluation
-    std::vector<std::vector<double>> beta;
+        // set all coordinate values for this step
+        for (size_t i = 0; i < ncoords; ++i) {
+            Discretization const& discr = discs[i];
+            double step = (discr.end - discr.begin) / discr.nsteps;
+            double val =  discr.begin + step*discr.end;
+            coords[i]->setValue(state, val);
+        }
 
-    // vector of an index in the evalsPair
-    std::vector<int> loc;
+        // eval the length of the PBP for this permutation of coordinate values
+        {
+            double eval = pbp.getLength(state);
+            rv.push_back(eval);
+        }
 
-    // discretization vector containing, for each dimension, a struct that
-    // contains [begin, end, number of points, step-size]
-    std::vector<Discretization> dS;
-
-    // vector of coordinate pointers which are used to relate an incoming state
-    // to a vector of relevant coordinates for the interpolation
-    std::vector<const OpenSim::Coordinate *> coords;
-
-public:
-    Interpolate() = default;
-
-    // Precomputed data constructor (length evaluations are already known)
-    Interpolate(
-            std::vector<OpenSim::Coordinate const*> coordsIn,
-            std::vector<Discretization> dSIn,
-            std::vector<double> evalsIn) :
-
-        dimensions(static_cast<int>(dSIn.size())),
-        evals(evalsIn),
-        n(dimensions, 0),
-        u(dimensions, 0),
-        loc(dimensions, 0),
-        dS(dSIn),
-        coords(coordsIn)
-    {
-        std::vector<double> dc_;
-        for (size_t i = 0; i < static_cast<size_t>(dimensions); i++) {
-            beta.push_back({0, 0, 0, 0});
-
-            linspace(dS[i], dc_);
-            discretizations.push_back(dc_);
-            discSizes.push_back(dS[i].gridsize);
+        // update which coordinate steps we're up to for each coordinate
+        //
+        // always updates "least significant" coordinate first, then performs
+        // "carry propagation" to the "more significant" coordinates
+        int pos = ncoords - 1;
+        discStepIdx[pos]++;
+        while (pos > 0 && discStepIdx[pos] >= discs[pos].nsteps) {
+            discStepIdx[pos] = 0;  // overflow
+            ++discStepIdx[pos-1];  // carry
+            --pos;  // propagate
         }
     }
 
-    // Precomputed data constructor without explicit coords
-    // used as a creation of an interpolation object after reading the data in
-    // extendFinalizeProperties. The coordinates are then related when the
-    // model is connected (as we need to sample the coordinates that affect a
-    // muscle again)
-    Interpolate(
-            std::vector<Discretization> dSIn,
-            std::vector<double> evalsIn) :
-
-        dimensions(static_cast<int>(dSIn.size())),
-        evals(evalsIn),
-        n(dimensions, 0),
-        u(dimensions, 0),
-        loc(dimensions, 0),
-        dS(dSIn),
-        coords(std::vector<const OpenSim::Coordinate*>(static_cast<size_t>(dimensions)))
-    {
-        std::vector<double> dc_;
-        for (size_t i = 0; i < static_cast<size_t>(dimensions); i++) {
-            beta.push_back({0, 0, 0, 0});
-
-            linspace(dS[i], dc_);
-            discretizations.push_back(dc_);
-            discSizes.push_back(dS[i].gridsize);
-        }
+    SimTK_ASSERT_ALWAYS(discStepIdx[0] == discs[0].nsteps, "should be true, after the final overflow");
+    for (size_t i = 1; i < discStepIdx.size(); ++i) {
+        SimTK_ASSERT_ALWAYS(discStepIdx[i] == 0, "these less-significant coordinates should all be overflow-n by the end of the alg");
     }
+    SimTK_ASSERT_ALWAYS(rv.size() == static_cast<size_t>(expectedEvals), "these two values should match, given the above alg");
 
-    // General interface constructor
-    // allows one to create an interface constructor as shown below with a
-    // vector of coordinates. This is the 'from scratch' constructor that you
-    // could use manually
-    Interpolate(OpenSim::PointBasedPath const& pbp,
-                OpenSim::Coordinate const** cBegin,
-                OpenSim::Coordinate const** cEnd,
-                SimTK::State& st,
-                std::vector<int>& nPoints) :
-
-        dimensions(static_cast<int>(nPoints.size())),
-        n(dimensions,0),
-        u(dimensions,0),
-        loc(dimensions,0)
-    {
-        // get the size of the 'vector'. Inclusive bottom, exclusive top
-        std::ptrdiff_t n = (cEnd - cBegin) + 1;
-        assert(n > 0);
-        assert(dimensions == (int)n);
-
-        for (int i = 0; i < dimensions; i++) {
-            // put all coordinate pointers in a vector to later unpack an
-            // incoming state to a vector of coordinate values
-            coords.push_back(cBegin[i]);
-            // fill an n-dimensional vector of 4 sized vectors which represent
-            // the polynomial values
-            beta.push_back({0,0,0,0});
-        }
-
-        // unlock coordinates
-        for (int i = 0; i < dimensions; i++) {
-            const OpenSim::Coordinate& c = *cBegin[i];
-            bool c_was_locked = c.getLocked(st);
-            c.setLocked(st, false);
-            auto unlock_c = defer_action([&] { c.setLocked(st, c_was_locked); });
-            double c_initial_value = c.getValue(st);
-            auto reset_c_val = defer_action([&] { c.setValue(st, c_initial_value); });
-        }
-
-        // make discretization objects for interpolation class instance
-        Discretization dc;
-        for (int i = 0; i < dimensions; i++) {
-            const OpenSim::Coordinate& c = *cBegin[i];
-            dc.begin = -static_cast<double>(SimTK_PI)/2;
-            dc.end = static_cast<double>(SimTK_PI)/2;
-//            dc.begin = std::max(c.getRangeMin(), -static_cast<double>(SimTK_PI));
-//            dc.end = std::min(c.getRangeMax(), static_cast<double>(SimTK_PI));
-            dc.nPoints = nPoints[i];
-            dc.gridsize = (dc.end - dc.begin) / (dc.nPoints - 1);
-            dS.push_back(dc);
-        }
-
-        // slightly extend the bound for accurate interpolation on the edges
-        for (int dim = 0; dim < dimensions; dim++) {
-            dS[dim].begin   -= 1*dS[dim].gridsize;
-            dS[dim].end     += 2*dS[dim].gridsize;
-            dS[dim].nPoints += 3;
-        }
-
-        // compute the total number of evaluations we need to do
-        int numOfLoops = 1;
-        for (int i = 0; i < dimensions; i++) {
-            numOfLoops *= dS[i].nPoints;
-        }
-
-        std::vector<int> cnt(dimensions);
-        std::vector<double> coordValues(dimensions);
-        for (int i = 0; i < numOfLoops; i++) {
-            for (int ii = 0; ii < dimensions; ii++) {
-                coordValues[ii] = dS[ii].begin + (cnt[ii]*dS[ii].gridsize);
-                const OpenSim::Coordinate& c = *cBegin[ii];
-                c.setValue(st,coordValues[ii]);
-            }
-            evals.push_back((pbp.getLength(st)));
-
-            // update cnt values
-            for (int x = dimensions-1; x >= 0; x--) {
-                if (cnt[x] != dS[x].nPoints-1){
-                    cnt[x] += 1;
-                    break;
-                } else {
-                    for (int y = x; y < dimensions; y++) {
-                        cnt[y] = 0;
-                    }
-                }
-            }
-        }
-
-        // just make it for using the old getInterp method
-        std::vector<double> dc_;
-        for (int i = 0; i < dimensions; i++) {
-            dc_.clear();
-            linspace(dS[i].begin, dS[i].end, dS[i].nPoints, dc_);
-            discretizations.push_back(dc_);
-            discSizes.push_back(dS[i].nPoints);
-        }
-    }
-
-    // Basic constructor having a vector of coordinate pointers as input
-    Interpolate(
-            OpenSim::PointBasedPath const& pbp,
-            std::vector<OpenSim::Coordinate const*> coords,
-            SimTK::State& st,
-            std::vector<int>& nPoints)  : Interpolate(pbp,
-                                                      &coords[0],
-                                                      &coords[coords.size()-1],
-                                                      st,
-                                                      nPoints)
-    {
-    }
-
-    std::vector<double> getRange(int i) const {
-        return discretizations[i];
-    }
-
-    int getDimension() const {
-        return dimensions;
-    }
-
-    std::vector<Discretization> getdS() const {
-        return dS;
-    }
-
-    std::vector<const OpenSim::Coordinate *> getCoords() const {
-        return coords;
-    }
-
-    void setCoords(std::vector<const OpenSim::Coordinate*> coordsIn) {
-        coords = coordsIn;
-    }
-
-    std::vector<double> getEvals() const {
-        return evals;
-    }
-
-    double getEval() {
-        // get the wrapping length evaluation given a vector 'loc' which contains,
-        // in ascending dimension, the index in each dimension
-        int factor = 1;
-        int idx = 0;
-
-        for (int i = 0; i < dimensions-1; i++) {
-            factor = 1;
-            for (int ii = i+1; ii <= dimensions-1; ii++) {
-                factor *= dS[ii].nPoints;
-            }
-            idx += loc[i]*factor;
-        }
-        idx += loc[loc.size()-1];
-
-        assert(idx <= evals.size());
-
-        return evals[idx];
-    }
-
-    // 0th derivative
-    double getInterp(const std::vector<double>& x) {
-        // This is the main interpolation function
-        // IN:  x, a vector of points within the considered interpolation range
-        // OUT: eval, the interpolated value
-        assert(x.size() == dimensions);
-
-//        // get the index of the closest range value to the discretization point
-//        for (int i = 0; i < dimensions; i++){
-//            n[i] = floor((x[i]-dS[i].begin)/dS[i].gridsize);
-//        }
-
-//        // compute remaining fraction
-//        for (int i = 0; i < dimensions; i++){
-//            u[i] = (x[i]-(dS[i].begin + n[i]*dS[i].gridsize))/(dS[i].gridsize);
-//        }
-        // get the index of the closest range value to the discretization point
-        for (int i=0; i<dimensions; i++){
-            auto it = std::find_if(std::begin(discretizations[i]),
-                                   std::end(discretizations[i]),
-                                   [&](double j){return j >= x[i];});
-            n[i] = std::distance(discretizations[i].begin(), it)-1;
-        }
-
-        // compute remaining fraction
-        for (int i=0; i<dimensions; i++){
-            u[i] = (x[i]-discretizations[i][n[i]])/
-                    (discretizations[i][2]-discretizations[i][1]);
-        }
-
-        // compute the polynomials (already evaluated)
-        for (int i = 0; i < dimensions; i++){
-            // compute binomial coefficient
-            beta[i][0] = (0.5*pow(u[i] - 1,3)*u[i]*(2*u[i] + 1));
-            beta[i][1] = (-0.5*(u[i] - 1)*(6*pow(u[i],4) - 9*pow(u[i],3) + 2*u[i] + 2));
-            beta[i][2] = (0.5*u[i]*(6*pow(u[i],4) - 15*pow(u[i],3) + 9*pow(u[i],2) + u[i] + 1));
-            beta[i][3] = (-0.5*(u[i] - 1)*pow(u[i],3)*(2*u[i] - 3));
-        }
-
-        // loop over all the considered points (n-dimensional) and multiply the
-        // evaluation with the weight
-
-        // create an array containing the  lengths of each discretization direction
-        std::vector<int> discrLoopCnt(dimensions);
-        for (int i = 0; i < dimensions; i++) {
-            discrLoopCnt[i] = -1;
-        }
-
-        double z = 0;
-        double Beta = 1;
-        for (int cnt=0; cnt<pow(4,dimensions); cnt++){
-            Beta = 1;
-            for (int i=0; i<dimensions; i++){
-                Beta *= beta[i][discrLoopCnt[i]+1];
-            }
-
-            for (int i=0; i<dimensions; i++){
-                loc[i] = discrLoopCnt[i] + n[i];
-            }
-
-            z += getEval()*Beta;
-
-            for (int x=dimensions-1; x>=0; x--){
-                if (discrLoopCnt[x] != 2){
-                    discrLoopCnt[x] += 1;
-                    break;
-                }
-                if (discrLoopCnt[x] == 2){
-                    for (int y=x; y<dimensions; y++){
-                        discrLoopCnt[y] = -1;
-                    }
-                }
-            }
-        }
-        return z;
-    }
-
-    // getLength with mapping from State to vector x
-    double getInterp(const SimTK::State& s) {
-        assert(coords.size() != 0);
-
-        std::vector<double> x;
-        for (const OpenSim::Coordinate* c : coords) {
-            x.push_back(c->getValue(s));
-        }
-
-        return getInterp(x);
-    }
-
-    // getLength based on the state
-    double getLength(const SimTK::State& s) {
-        return getInterp(s);
-    }
-
-    // 1st derivative
-    double getInterpDer(const std::vector<double>& x,
-                        int coordinate,
-                        double h = 0.0001) {
-
-        assert(x.size() == dimensions);
-        assert(coordinate <= dimensions-1);
-        assert(h>0 && h < (dS[coordinate].end - x[coordinate]));
-
-        // This is the main interpolation function for derivatives
-        // IN:  x, a vector of points within the considered interpolation range
-        //      coordinate, the generalized coordinate of which we take derivative
-        // OUT: eval, the interpolated value
-        double f1 = getInterp(x);
-
-        std::vector<double> x2 = x;
-        x2[coordinate] += h;
-        double f2 = getInterp(x2);
-
-        return (f2 - f1)/h;
-    }
-
-    double getInterpDer(const SimTK::State& s, int coordinate) {
-        assert(coords.size() != 0);
-
-        std::vector<double> x;
-        for (size_t i = 0; i < coords.size(); i++) {
-            x.push_back(coords[i]->getValue(s));
-        }
-        return getInterpDer(x,coordinate);
-    }
-
-    double getInterpDer(const SimTK::State& s,
-                        const OpenSim::Coordinate& aCoord) {
-
-        for (size_t i = 0; i < coords.size(); i++) {
-            if (coords[i]->getName() == aCoord.getName()) {
-                return getInterpDer(s, i);
-            }
-        }
-        OPENSIM_THROW(OpenSim::Exception,"could not find coordinate in getInterpDer based on given coord argument")
-        return 0.0;
-    }
-
-    double getLengtheningSpeed(const SimTK::State& s) {
-        double lengtheningSpeed = 0.0;
-
-        for (int i = 0; i < dimensions; i++) {
-            double firstDeriv = getInterpDer(s, i);
-            double coordinateSpeedVal = coords[i]->getSpeedValue(s);
-
-            lengtheningSpeed += firstDeriv * coordinateSpeedVal;
-        }
-        return lengtheningSpeed;
-    }
-};
-
-// ----- FunctionBasedPath implementation -----
+    return rv;
+}
 
 struct OpenSim::FunctionBasedPath::Impl final {
-    mutable Interpolate interp;
+    // direct pointers to the coordinates that were discretized
+    std::vector<OpenSim::Coordinate const*> coords;
 
+    // absolute paths of each coordinate (1:1 with coords)
+    std::vector<std::string> coordAbsPaths;
+
+    // discretizations ranges for each coordinate (1:1 with coords)
+    std::vector<Discretization> discretizations;
+
+    // evaluations for each permutation of coordinates' discretizations
+    std::vector<double> evals;
+
+    // satisfies clone-ability requirement of SimTK::ClonePtr
     Impl* clone() const {
-        auto p = std::unique_ptr<Impl>{new Impl{}};
-        p->interp = interp;
+        auto p = std::unique_ptr<Impl>{new Impl{*this}};
         return p.release();
     }
 };
+
+// compute fresh implementation data from an existing PointBasedPath by
+// evaluating it and fitting it to a function-based curve
+static void Impl_ComputeFromPBP(OpenSim::FunctionBasedPath::Impl& impl,
+                                const OpenSim::Model& model,
+                                const OpenSim::PointBasedPath& pbp) {
+
+    // copy model, so we can independently equilibrate + realize + modify the
+    // copy without having to touch the source model
+    std::unique_ptr<OpenSim::Model> modelClone{model.clone()};
+    SimTK::State& initialState = modelClone->initSystem();
+    modelClone->equilibrateMuscles(initialState);
+    modelClone->realizeVelocity(initialState);
+
+    // set `coords`
+    impl.coords = coordsThatAffectPBP(*modelClone, pbp, initialState);
+
+    // set `coordAbsPaths`
+    impl.coordAbsPaths.clear();
+    impl.coordAbsPaths.reserve(impl.coords.size());
+    for (const OpenSim::Coordinate* c : impl.coords) {
+        impl.coordAbsPaths.push_back(c->getAbsolutePathString());
+    }
+
+    // set `discretizations`
+    impl.discretizations.clear();
+    impl.discretizations.reserve(impl.coords.size());
+    for (const OpenSim::Coordinate* c : impl.coords) {
+        impl.discretizations.push_back(discretizationForCoord(*c));
+    }
+
+    // set `evals`
+    SimTK_ASSERT_ALWAYS(impl.coords.size() == impl.discretizations.size(), "these should be equal by now");
+    impl.evals = computeEvaluationsFromPBP(pbp, initialState, impl.coords.data(), impl.discretizations.data(), impl.coords.size());
+}
+
+// init underlying implementation data from a `FunctionBasedPath`s (precomputed) properties
+//
+// the properties being set in the FBP usually implies that the FBP has already been built
+// from a PBP at some previous point in time
+static void Impl_InitFromFBPProperties(OpenSim::FunctionBasedPath::Impl& impl,
+                                       OpenSim::FunctionBasedPath const& fbp) {
+
+    OpenSim::FunctionBasedPathDiscretizationSet const& discSet = fbp.getProperty_FunctionBasedPathDiscretizationSet().getValue();
+
+    // set `coords` pointers to null
+    //
+    // they are lazily looked up in a later phase (after the model is connected up)
+    impl.coords.clear();
+    impl.coords.resize(discSet.getSize(), nullptr);
+
+    // set `coordAbsPaths` from discretizations property
+    impl.coordAbsPaths.clear();
+    impl.coordAbsPaths.reserve(discSet.getSize());
+    for (int i = 0; i < discSet.getSize(); ++i) {
+        impl.coordAbsPaths.push_back(discSet[i].getProperty_coordinate_abspath().getValue());
+    }
+
+    // set `discretizations` from discretizations property
+    impl.discretizations.clear();
+    impl.discretizations.reserve(discSet.getSize());
+    for (int i = 0; i < discSet.getSize(); ++i) {
+        OpenSim::FunctionBasedPathDiscretization const& disc = discSet[i];
+        Discretization d;
+        d.begin = disc.getProperty_x_begin().getValue();
+        d.end = disc.getProperty_x_end().getValue();
+        d.nsteps = disc.getProperty_num_points().getValue();
+        impl.discretizations.push_back(d);
+    }
+
+    // set `evals` from evaluations property
+    auto const& evalsProp = fbp.getProperty_Evaluations();
+    impl.evals.clear();
+    impl.evals.reserve(evalsProp.size());
+    for (int i = 0; i < evalsProp.size(); ++i) {
+        impl.evals.push_back(evalsProp.getValue(i));
+    }
+}
+
+// ensure that the OpenSim::Coordinate* pointers held in Impl are up-to-date
+//
+// the pointers are there to reduce runtime path lookups
+static void Impl_SetCoordinatePointersFromCoordinatePaths(OpenSim::FunctionBasedPath::Impl& impl,
+                                                          OpenSim::Component const& c) {
+
+    for (size_t i = 0; i < impl.coords.size(); ++i) {
+        impl.coords[i] = &c.getComponent<OpenSim::Coordinate>(impl.coordAbsPaths[i]);
+    }
+}
+
+// returns interpolated path length for a given permutation of coordinate
+// values
+//
+// `inputVals` points to a sequence of `nCoords` values that were probably
+// retrieved via `Coordinate::getValue(SimTK::State const&)`. The reason
+// they're provided externally is because derivative calculation can fiddle
+// the values a little bit
+static double Impl_GetPathLength(OpenSim::FunctionBasedPath::Impl const& impl,
+                                 double const* inputVals,
+                                 int nCoords) {
+
+    SimTK_ASSERT_ALWAYS(!impl.coords.empty(), "FBPs require at least one coordinate to affect the path");
+    SimTK_ASSERT_ALWAYS(nCoords == static_cast<int>(impl.coords.size()), "You must call this function with the correct number of (precomputed) coordinate values");
+
+    // compute:
+    //
+    // - the index of the first discretization step *before* the input value
+    // - the polynomial of the curve at that step, given its fractional distance
+    //   toward the next step
+    using Polynomial = std::array<double, 4>;
+    std::array<int, g_MaxCoordsThatCanBeInterpolated> closestDiscretizationSteps{};
+    std::array<Polynomial, g_MaxCoordsThatCanBeInterpolated> betas{};
+    for (int coord = 0; coord < nCoords; ++coord) {
+        double inputVal = inputVals[coord];
+        Discretization const& disc = impl.discretizations[coord];
+
+        // compute index of first discretization step *before* the input value and
+        // the fraction that the input value is towards the *next* discretization step
+        int idx = -1;
+        double frac = -1337.0;
+        if (inputVal < disc.begin) {
+            idx = 0;
+            frac = 0.0;
+        } else if (inputVal > disc.end) {
+            idx = disc.nsteps-1;
+            frac = 0.0;
+        } else {
+            // solve for `n`: inputVal = begin + n*step
+            double step = (disc.end - disc.begin) / (disc.nsteps - 1);
+            double n = (inputVal - disc.begin) / step;
+            double wholePart;
+            double fractionalPart = std::modf(n, &wholePart);
+
+            idx = static_cast<int>(wholePart);
+            frac = fractionalPart;
+        }
+
+        // compute polynomial based on fraction the point is toward the next point
+        Polynomial p;
+        p[0] = +0.5*pow(frac - 1.0, 3)*frac*(2.0*frac + 1.0);
+        p[1] = -0.5*(frac - 1.0)*(6.0*pow(frac, 4) - 9.0*pow(frac, 3.0) + 2*frac + 2.0);
+        p[2] = +0.5*frac*(6.0*pow(frac, 4) - 15.0*pow(frac, 3) + 9.0*pow(frac, 2) + frac + 1);
+        p[3] = -0.5*(frac - 1.0)*pow(frac, 3)*(2.0*frac - 3.0);
+
+        closestDiscretizationSteps[coord] = idx;
+        betas[coord] = p;
+    }
+
+    // for each coord, permute through 4 locations *around* the input's location:
+    //
+    // - A one step before B
+    // - B the first discretization step before the input value
+    // - C one step after B
+    // - D one step after C
+    //
+    // where:
+    //
+    // - betas are coefficients that affect each location. beta[0] affects A,
+    //   betas[1] affects B, betas[2] affects C, and betas[3] affects D
+
+    // represent permuting through each location around each coordinate as a string
+    // of integer offsets that can be -1, 0, 1, or 2
+    //
+    // the algorithm increments this array as it goes through each permutation
+    std::array<int, g_MaxCoordsThatCanBeInterpolated> dimIdxOffsets;
+    for (int coord = 0; coord < nCoords; ++coord) {
+        dimIdxOffsets[coord] = -1;
+    }
+
+    // permute through all locations around the input value
+    //
+    // e.g. the location permutations for 3 coords iterate like this for each
+    //      crank of the loop
+    //
+    //     [-1, -1, -1]
+    //     [-1, -1,  0]
+    //     [-1, -1,  1]
+    //     [-1, -1,  2]
+    //     [-1,  0, -1]
+    //     ...(4^3 steps total)...
+    //     [ 2,  2,  1]
+    //     [ 2,  2,  2]
+    //     [ 3,  0,  0]   (the termination condition)
+
+    double z = 0.0;
+    while (dimIdxOffsets[0] < 3) {
+
+        // compute `beta` (weighted coefficient per coord) for this particular
+        // permutation coordinate locations (e.g. -1, 0, 0, 2) and figure out
+        // what the closest input value was at the weighted location. Add the
+        // result the the output
+
+        double beta = 1.0;
+        int evalStride = 1;  // space between evaluations: gets bigger at lower idx coords
+        int evalIdx = 0;
+
+        // go backwards, from least-significant coordinate (highest idx)
+        //
+        // this is so that we can compute the stride as the algorithm runs
+        for (int coord = nCoords-1; coord >= 0; --coord) {
+            int offset = dimIdxOffsets[coord];  // -1, 0, 1, or 2
+            int closestStep = closestDiscretizationSteps[coord];
+            int step = closestStep + offset;
+
+            beta *= betas[coord][offset+1];
+            evalIdx += evalStride * step;
+            evalStride *= impl.discretizations[coord].nsteps;
+        }
+
+        z += beta * impl.evals[evalIdx];
+
+        // increment the offsets
+        //
+        // this is effectively the step that permutes [-1, -1, 2] --> [-1,  0, -1]
+        {
+            int pos = nCoords-1;
+            ++dimIdxOffsets[pos];  // perform first (potentially overflowing) increment
+            while (pos > 0 && dimIdxOffsets[pos] >= 2) {  // handle overflows + carry propagation
+                dimIdxOffsets[pos] = 0;  // overflow
+                ++dimIdxOffsets[pos-1];  // carry propagation
+                --pos;
+            }
+        }
+    }
+
+    return z;
+}
+
+// get the length of the path in the current state
+static double Impl_GetPathLength(OpenSim::FunctionBasedPath::Impl const& impl,
+                                 SimTK::State const& s) {
+
+    int nCoords = static_cast<int>(impl.coords.size());
+
+    // get the input value of each coordinate in the current state
+    std::array<double, g_MaxCoordsThatCanBeInterpolated> inputVals{};
+    for (int coord = 0; coord < nCoords; ++coord) {
+        inputVals[coord] = impl.coords[coord]->getValue(s);
+    }
+
+    return Impl_GetPathLength(impl, inputVals.data(), nCoords);
+}
+
+// get the *derivative* of the path length with respect to the given Coordinate index
+// (in impl.coords)
+static double Impl_GetPathLengthDerivative(OpenSim::FunctionBasedPath::Impl const& impl,
+                                           SimTK::State const& s,
+                                           int coordIdx) {
+
+    SimTK_ASSERT_ALWAYS(!impl.coords.empty(), "FBPs require at least one coordinate to affect the path");
+    SimTK_ASSERT_ALWAYS(coordIdx != -1, "coord index must be valid");
+    SimTK_ASSERT_ALWAYS(coordIdx < static_cast<int>(impl.coords.size()), "coord index must be valid");
+
+    int nCoords = static_cast<int>(impl.coords.size());
+
+    // get the input value of each coordinate in the current state
+    std::array<double, g_MaxCoordsThatCanBeInterpolated> inputVals{};
+    for (int coord = 0; coord < nCoords; ++coord) {
+        inputVals[coord] = impl.coords[coord]->getValue(s);
+    }
+
+    // compute value at current point
+    double v1 = Impl_GetPathLength(impl, inputVals.data(), nCoords);
+
+    // alter the input value for the to-be-derived coordinate *slightly*
+    inputVals[coordIdx] += 0.0001;
+
+    // compute value at the altered point
+    double v2 = Impl_GetPathLength(impl, inputVals.data(), nCoords);
+
+    // the derivative is how much the output changed when the input was altered
+    // slightly (this is a poor-man's discrete derivative method)
+    return (v2 - v1) / 0.0001;
+}
+
+// get the *derivative* of the path length with respect to the given Coordinate
+static double Impl_GetPathLengthDerivative(OpenSim::FunctionBasedPath::Impl const& impl,
+                                           SimTK::State const& s,
+                                           OpenSim::Coordinate const& c) {
+
+    // figure out the index of the coordinate being referred to
+    int coordIdx = -1;
+    for (int i = 0; i < static_cast<int>(impl.coords.size()); ++i) {
+        if (impl.coords[i] == &c) {
+            coordIdx = i;
+            break;
+        }
+    }
+
+    // ensure the coordinate was actually found, or this alg will break
+    if (coordIdx == -1) {
+        std::stringstream msg;
+        msg << "could not find coordiante '" << c.getName() << "' in the set of coordinates the FunctionBasedPath handles. Coordinates handled by this path are: ";
+        char const* delim = "";
+        for (OpenSim::Coordinate const* c : impl.coords) {
+            msg << delim << c->getName();
+            delim = ", ";
+        }
+        OPENSIM_THROW(OpenSim::Exception, std::move(msg).str());
+    }
+
+    // use the "raw" (non-lookup) version of this function
+    return Impl_GetPathLengthDerivative(impl, s, coordIdx);
+}
+
+// get the lengthening speed of the path in the current state
+static double Impl_GetLengtheningSpeed(const OpenSim::FunctionBasedPath::Impl& impl,
+                                       const SimTK::State& state) {
+    double rv = 0.0;
+    for (int coord = 0; coord < static_cast<int>(impl.coords.size()); ++coord) {
+        double deriv = Impl_GetPathLengthDerivative(impl, state, coord);
+        double speed = impl.coords[coord]->getSpeedValue(state);
+        rv += deriv * speed;
+    }
+    return rv;
+}
+
+//----------------------------------------------------------------------------
+//                               PUBLIC API
+//----------------------------------------------------------------------------
 
 OpenSim::FunctionBasedPath OpenSim::FunctionBasedPath::fromPointBasedPath(
         const Model& model,
@@ -539,284 +533,38 @@ OpenSim::FunctionBasedPath OpenSim::FunctionBasedPath::fromPointBasedPath(
 {
     FunctionBasedPath fbp;
 
-    // copy relevant data from source PBP
+    // copy relevant data from source PBP into the output FBP
     fbp.upd_Appearance() = pbp.get_Appearance();
     fbp.setPathPointSet(pbp.getPathPointSet());
     fbp.setPathWrapSet(pbp.getWrapSet());
 
-    std::unique_ptr<OpenSim::Model> modelClone{model.clone()};
-    SimTK::State& initialState = modelClone->initSystem();
-    modelClone->equilibrateMuscles(initialState);
-    modelClone->realizeVelocity(initialState);
+    OpenSim::FunctionBasedPath::Impl& impl = *fbp._impl;
 
-    std::vector<const Coordinate *> coordsThatAffectPBP;
-    for (Coordinate const& c : modelClone->getComponentList<Coordinate>()){
-        if (c.getMotionType() == Coordinate::MotionType::Coupled) {
-            continue;
-        }
+    // compute underlying impl data from the model + PBP
+    Impl_ComputeFromPBP(impl, model, pbp);
 
-        if (!coordinateAffectsPBP(pbp, c, initialState)) {
-            continue;
-        }
-
-        coordsThatAffectPBP.push_back(&c);
-        std::cout << "affecting coord: " << c.getName() << std::endl;
+    // write impl discretizations into the property (for later serialization)
+    OpenSim::FunctionBasedPathDiscretizationSet& set = fbp.updProperty_FunctionBasedPathDiscretizationSet().updValue();
+    for (size_t i = 0; i < impl.coords.size(); ++i) {
+        auto disc = std::unique_ptr<OpenSim::FunctionBasedPathDiscretization>{new FunctionBasedPathDiscretization{}};
+        disc->set_x_begin(impl.discretizations[i].begin);
+        disc->set_x_end(impl.discretizations[i].end);
+        disc->set_num_points(impl.discretizations[i].nsteps);
+        disc->set_coordinate_abspath(impl.coordAbsPaths[i]);
+        set.adoptAndAppend(disc.release());
     }
 
-    // create vector for number of interpolation points
-    std::vector<int> nPoints(coordsThatAffectPBP.size(), 80);
-
-    // reinitialize the default-initialized interp with the points
-    fbp._impl->interp = Interpolate{
-            pbp,
-            std::move(coordsThatAffectPBP),
-            initialState,
-            nPoints
-    };
-
-    return fbp;
-}
-
-static Interpolate readInterp(const std::string &path) {
-    // data file for FunctionBasedPath top-level structure:
-    //
-    //     - plaintext
-    //     - line-oriented
-    //     - 3 sections (HEADERS, DISCRETIZATIONS, and EVALUATIONS) separated
-    //       by blank lines
-    //
-    // details:
-    //
-    // line                                  content
-    // -------------------------------------------------------------------
-    // 0                                     ID (string)
-    // 1                                     <empty>
-    // 2                                     DIMENSIONS (int)
-    // 3                                     <empty>
-    // --- end HEADERS
-    // 4                                     DISCRETIZATION_1
-    // 5                                     DISCRETIZATION_2
-    // 6-                                    DISCRETIZATION_n
-    // 3+DIMENSIONS                          DISCRETIZATION_${DIMENSIONS}
-    // 3+DIMENSIONS+1                        <empty>
-    // --- end DISCRETIZATIONS
-    // 3+DIMENSIONS+2                        EVAL_1_1
-    // 3+DIMENSIONS+3                        EVAL_1_2
-    // 3+DIMENSIONS+4-                       EVAL_1_m
-    // 3+DIMENSIONS+${points_in_range}       EVAL_1_${points_in_range}
-    // 3+DIMENSIONS+${points_in_range}+1     EVAL_2_1
-    // ...
-    // ? (depends on points_in_range for each discretization)
-    // ?                                     EVAL_${DIMENSIONS}_${points_in_range}
-    // EOF
-    //
-    // where DISCRETIZATION_$n is tab-delimited (\t) line that describes
-    // evenly-spaced points along the `n`th DIMENSION:
-    //
-    // column           content
-    // ------------------------------------------------
-    // 0                range_start (float)
-    // 1                range_end (float)
-    // 2                points_in_range (int)
-    // 3                grid_size (float)
-    //
-    // and EVAL_$n_$m is a line that contains a single real-valued evaluation
-    // of the curve at:
-    //
-    //     range_start + (m * ((range_end - range_start)/points_in_range))
-    //
-    // along DIMENSION `n`
-
-    std::ifstream file{path};
-
-    if (!file) {
-        std::stringstream msg;
-        msg << path << ": error opening FunctionBasedPath data file";
-        OPENSIM_THROW(OpenSim::Exception, std::move(msg).str());
+    // write evals into FBP property
+    for (double eval : fbp._impl->evals) {
+        fbp.updProperty_Evaluations().appendValue(eval);
     }
-
-    int lineno = 0;
-    std::string line;
-
-    // ID (ignored)
-    while (std::getline(file, line)) {
-        ++lineno;
-
-        if (lineno >= 2) {
-            break;
-        }
-    }
-
-    // DIMENSIONS
-    int dimensions = -1;
-    while (std::getline(file, line)) {
-        ++lineno;
-        if (line.empty()) {
-            if (dimensions <= -1) {
-                std::stringstream msg;
-                msg << path << ": L" << lineno << ": unexpected blank line (expected dimensions)";
-                OPENSIM_THROW(OpenSim::Exception, std::move(msg).str());
-            }
-            break;
-        }
-
-        dimensions = std::stoi(line.c_str());
-    }
-
-    // COORDINATES
-    std::string coordsExist = "";
-    std::vector<std::string> coordinates;
-    while (std::getline(file,line)) {
-        ++lineno;
-
-        if (line.empty()) {
-            if (coordsExist == ""){
-                std::stringstream msg;
-                msg << path << ": L" << lineno << ": unexpected blank line (expected coordinates)";
-                OPENSIM_THROW(OpenSim::Exception, std::move(msg).str());
-            }
-            break;
-        }
-        coordsExist = line.c_str();
-        coordinates.push_back(line.c_str());
-    }
-
-    // [DISCRETIZATION_1..DISCRETIZATION_n]
-    std::vector<Discretization> discretizations;
-    discretizations.reserve(static_cast<size_t>(dimensions));
-    while (std::getline(file, line)) {
-        ++lineno;
-
-        if (line.empty()) {
-            if (discretizations.size() != static_cast<size_t>(dimensions)) {
-                std::stringstream msg;
-                msg << path << ": L" << lineno << ": invalid number of discretizations in this file: expected: " << dimensions << " got " << discretizations.size();
-                OPENSIM_THROW(OpenSim::Exception, std::move(msg).str());
-            }
-
-            break;  // end of DISCRETIZATIONs
-        }
-
-        // DISCRETIZATION_i
-        Discretization d;
-        std::sscanf(line.c_str(), "%lf\t%lf\t%i\t%lf", &d.begin, &d.end, &d.nPoints, &d.gridsize);
-        discretizations.push_back(d);
-    }
-
-    // [EVAL_1_1..EVAL_n_m]
-    std::vector<double> evals;
-    while (std::getline(file, line)) {
-        ++lineno;
-
-        if (line.empty()){
-            break;  // end of EVALs
-        }
-
-        evals.push_back(atof(line.c_str()));
-    }
-
-    // sanity check
-    {
-        size_t expectedEvals = 1;
-        for (const Discretization& d : discretizations) {
-            expectedEvals *= static_cast<size_t>(d.nPoints);
-        }
-
-        if (expectedEvals != evals.size()) {
-            std::stringstream msg;
-            msg << path << ": L" << lineno << ": invalid number of function evaluations in this file: expected " << expectedEvals << " got " << evals.size();
-            OPENSIM_THROW(OpenSim::Exception, std::move(msg).str());
-        }
-    }
-
-    return Interpolate{
-        std::vector<const OpenSim::Coordinate*>(static_cast<size_t>(dimensions)),
-        std::move(discretizations),
-        std::move(evals)
-    };
-}
-
-static std::vector<const OpenSim::Coordinate*> readInterpCoords(const std::string& path, OpenSim::Component& root) {
-    std::ifstream file{path};
-
-    if (!file) {
-        std::stringstream msg;
-        msg << path << ": error opening FunctionBasedPath data file";
-        OPENSIM_THROW(OpenSim::Exception, std::move(msg).str());
-    }
-
-    int lineno = 0;
-    std::string line;
-
-    // ID (ignored)
-    while (std::getline(file, line)) {
-        ++lineno;
-
-        if (lineno >= 2) {
-            break;
-        }
-    }
-
-    // DIMENSIONS
-    int dimensions = -1;
-    while (std::getline(file, line)) {
-        ++lineno;
-        if (line.empty()) {
-            if (dimensions <= -1) {
-                std::stringstream msg;
-                msg << path << ": L" << lineno << ": unexpected blank line (expected dimensions)";
-                OPENSIM_THROW(OpenSim::Exception, std::move(msg).str());
-            }
-            break;
-        }
-
-        dimensions = std::stoi(line.c_str());
-    }
-
-    // COORDINATES
-    std::string coordsExist = "";
-    std::vector<std::string> coordinates;
-    while (std::getline(file,line)) {
-        ++lineno;
-
-        if (line.empty()) {
-            if (coordsExist == ""){
-                std::stringstream msg;
-                msg << path << ": L" << lineno << ": unexpected blank line (expected coordinates)";
-                OPENSIM_THROW(OpenSim::Exception, std::move(msg).str());
-            }
-            break;
-        }
-        coordsExist = line.c_str();
-        coordinates.push_back(line.c_str());
-    }
-
-    std::vector<const OpenSim::Coordinate*> coords;
-    for (const std::string& coord : coordinates) {
-        const OpenSim::Component& comp = root.getComponent(coord);
-        if (comp.getAbsolutePathString() == coord){
-            const OpenSim::Coordinate* c = dynamic_cast<const OpenSim::Coordinate*>(&comp);
-            coords.push_back(c);
-        }
-    }
-    return coords;
-}
-
-OpenSim::FunctionBasedPath OpenSim::FunctionBasedPath::fromDataFile(const std::string &path)
-{
-    FunctionBasedPath fbp;
-    fbp.setDataPath(path);
-
-    // the data file effectively only contains data for Interpolate, data file
-    // spec is in there
-    fbp._impl->interp = readInterp(path);
 
     return fbp;
 }
 
 OpenSim::FunctionBasedPath::FunctionBasedPath() : GeometryPath{}, _impl{new Impl{}}
 {
-    constructProperty_data_path("");
+    constructProperty_FunctionBasedPathDiscretizationSet(FunctionBasedPathDiscretizationSet{});
 }
 OpenSim::FunctionBasedPath::FunctionBasedPath(const FunctionBasedPath&) = default;
 OpenSim::FunctionBasedPath::FunctionBasedPath(FunctionBasedPath&&) = default;
@@ -826,34 +574,19 @@ OpenSim::FunctionBasedPath::~FunctionBasedPath() noexcept = default;
 
 void OpenSim::FunctionBasedPath::extendFinalizeFromProperties()
 {
-    Super::extendFinalizeFromProperties();
-
-    // when finalizing from properties, try to load the backing file that contains
-    // interpolated data (the `data_path` property)
-
-    bool hasBackingFile = !get_data_path().empty();
-    bool hasInMemoryFittingData =  !_impl->interp.getdS().empty();
-
-    if (hasBackingFile) {
-        // change to the directory of the model file (the path in the osim is relative to
-        // the osim, not the process's working directory)
-        auto cwdchanger = IO::CwdChanger::changeToParentOf(getRoot().getDocumentFileName());
-
-        // read the interpolation data into a new interpolation structure
-        _impl->interp = readInterp(get_data_path());
-    } else if (hasInMemoryFittingData) {
-        // do nothing: just use the already-loaded in-memory fitting data
-        return;
-    } else {
-        // error: has no backing file and has no in-memory fitting data
-        std::stringstream msg;
-        msg << getAbsolutePathString() << ": cannot call `.finalizeFromProperties()` on this `" << getConcreteClassName() << "`: the path has no fitting associated with it. A `FunctionBasedPath` must either have a valid `data_path` property that points to its underlying fitting data data, or be initialized using `FunctionBasedPath::fromPointBasedPath` (i.e. generate new fitting data)";
-        OPENSIM_THROW(OpenSim::Exception, std::move(msg).str());
-    }
+    Impl_InitFromFBPProperties(*_impl, *this);
 }
 
 void OpenSim::FunctionBasedPath::extendFinalizeConnections(OpenSim::Component& root)
 {
+
+    // populate pointer-based coordinate lookups
+    //
+    // the reason this isn't done in `extendFinalizeFromProperties` is because the
+    // not-yet-property-finalized Model hasn't necessarily "connected" to the
+    // coordinates that the coordinate files refer to, so the implementation
+    // can't lookup the `OpenSim::Coordinate*` pointers during that phase
+
     // Allow (model) component to include its own subcomponents
     // before calling the base method which automatically invokes
     // connect all the subcomponents.
@@ -864,27 +597,7 @@ void OpenSim::FunctionBasedPath::extendFinalizeConnections(OpenSim::Component& r
         }
     }
 
-    bool hasBackingFile = !get_data_path().empty();
-    bool hasInMemoryFittingData =  !_impl->interp.getdS().empty();
-
-    if (hasBackingFile) {
-        // change to the directory of the model file
-        auto cwdchanger = IO::CwdChanger::changeToParentOf(getRoot().getDocumentFileName());
-
-        // read the interp coords (text) file
-        std::vector<const OpenSim::Coordinate*> coords = readInterpCoords(get_data_path(), root);
-
-        // update interpolator implementation with the (deserialized) coordinates
-        _impl->interp.setCoords(std::move(coords));
-    } else if (hasInMemoryFittingData) {
-        // do nothing: just use the already-loaded in-memory fitting data
-        return;
-    } else {
-        // error: has no backing file and has no in-memory fitting data
-        std::stringstream msg;
-        msg << getAbsolutePathString() << ": cannot call `.finalizeConnections()` on this `" << getConcreteClassName() << "`: the path has no fitting associated with it. A `FunctionBasedPath` must either have a valid `data_path` property that points to its underlying fitting data data, or be initialized using `FunctionBasedPath::fromPointBasedPath` (i.e. generate new fitting data)";
-        OPENSIM_THROW(OpenSim::Exception, std::move(msg).str());
-    }
+    Impl_SetCoordinatePointersFromCoordinatePaths(*_impl, root);
 }
 
 double OpenSim::FunctionBasedPath::getLength(const SimTK::State& s) const
@@ -893,9 +606,9 @@ double OpenSim::FunctionBasedPath::getLength(const SimTK::State& s) const
         return getCacheVariableValue(s, _lengthCV);
     }
 
-    double rv = _impl->interp.getLength(s);
-    setCacheVariableValue(s, _lengthCV, rv);
-    return rv;
+    double v = Impl_GetPathLength(*_impl, s);
+    setCacheVariableValue(s, _lengthCV, v);
+    return v;
 }
 
 void OpenSim::FunctionBasedPath::setLength(const SimTK::State& s, double length) const
@@ -909,9 +622,9 @@ double OpenSim::FunctionBasedPath::getLengtheningSpeed(const SimTK::State& s) co
         return getCacheVariableValue(s, _speedCV);
     }
 
-    double rv = _impl->interp.getLengtheningSpeed(s);
-    setCacheVariableValue(s, _speedCV, rv);
-    return rv;
+    double v = Impl_GetLengtheningSpeed(*_impl, s);
+    setCacheVariableValue(s, _speedCV, v);
+    return v;
 }
 
 void OpenSim::FunctionBasedPath::setLengtheningSpeed(const SimTK::State& s, double speed) const
@@ -922,54 +635,9 @@ void OpenSim::FunctionBasedPath::setLengtheningSpeed(const SimTK::State& s, doub
 double OpenSim::FunctionBasedPath::computeMomentArm(const SimTK::State& s,
                                                     const Coordinate& aCoord) const
 {
-    return _impl->interp.getInterpDer(s,aCoord);
+    return Impl_GetPathLengthDerivative(*_impl, s, aCoord);
 }
 
-void OpenSim::FunctionBasedPath::printContent(std::ostream& out) const
-{
-    // see FunctionBasedPath::fromDataFile(const std::string &path) for format
-    // spec
-
-    // HEADERS
-    out << get_data_path() << '\n'
-        << '\n'
-        << _impl->interp.getDimension() << '\n'
-        << '\n';
-
-    // COORDINATES
-    for (const Coordinate* c : _impl->interp.getCoords()){
-        out << c->getAbsolutePathString() << "\n";
-    }
-    out << "\n";
-
-    // DISCRETIZATIONS
-    for (const Discretization& d : _impl->interp.getdS()) {
-        out << d.begin << '\t'
-            << d.end << '\t'
-            << d.nPoints << '\t'
-            << d.gridsize << '\n';
-    }
-    out << '\n';
-
-    // EVALS
-    for (double d : _impl->interp.getEvals()) {
-        out << d << '\n';
-    }
-
-    out.flush();
-}
-
-
-
-
-
-
-
-
-
-////////////////////////////////
-// Directly from GeometryPath //
-////////////////////////////////
 /* add in the equivalent spatial forces on bodies for an applied tension
     along the GeometryPath to a set of bodyForces */
 void OpenSim::FunctionBasedPath::addInEquivalentForces(const SimTK::State& s,
@@ -977,172 +645,142 @@ void OpenSim::FunctionBasedPath::addInEquivalentForces(const SimTK::State& s,
     SimTK::Vector_<SimTK::SpatialVec>& bodyForces,
     SimTK::Vector& mobilityForces) const
 {
-    const SimTK::SimbodyMatterSubsystem& matter =
-                                        getModel().getMatterSubsystem();
+    const SimTK::SimbodyMatterSubsystem& matter = getModel().getMatterSubsystem();
 
-    std::vector<const OpenSim::Coordinate*> coords = _impl->interp.getCoords();
-    for (unsigned i=0; i<coords.size(); i++){
-        double ma = computeMomentArm(s,*coords[i]);
-//        std::cout << "momentArm in addInEquivalentForces: " << ma << std::endl;
+    for (const OpenSim::Coordinate* coord : _impl->coords) {
+        double ma = computeMomentArm(s, *coord);
         double torqueOverCoord = -tension*ma;
 
         matter.addInMobilityForce(s,
-                                  SimTK::MobilizedBodyIndex(coords[i]->getBodyIndex()),
-                                  SimTK::MobilizerUIndex(coords[i]->getMobilizerQIndex()),
-                                  torqueOverCoord,mobilityForces);
+                                  SimTK::MobilizedBodyIndex(coord->getBodyIndex()),
+                                  SimTK::MobilizerUIndex(coord->getMobilizerQIndex()),
+                                  torqueOverCoord,
+                                  mobilityForces);
     }
 }
 
-// get the path as PointForceDirections directions
-// CAUTION: the return points are heap allocated; you must delete them yourself!
-// (TODO: that is really lame)
-void OpenSim::FunctionBasedPath::
-getPointForceDirections(const SimTK::State& s,
-                        OpenSim::Array<PointForceDirection*> *rPFDs) const
+void OpenSim::FunctionBasedPath::generateDecorations(
+        bool fixed,
+        const ModelDisplayHints& hints,
+        const SimTK::State& state,
+        SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    static bool shownOnce = []() {
+        OpenSim::log_warn("Tried to call `generateDecorations` on a `FunctionBasedPath`. This function call will be ignored (there is no easy way to visualize function-based paths)");
+        return true;
+    }();
+    (void)shownOnce;
 }
 
-//_____________________________________________________________________________
-/*
- * Calculate the current path.
- */
+
 void OpenSim::FunctionBasedPath::computePath(const SimTK::State& s) const
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `computePath` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it isn't path-based). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
 
-//_____________________________________________________________________________
-/*
- * Compute the total length of the path. This function
- * assumes that the path has already been updated.
- */
-double OpenSim::FunctionBasedPath::
-calcLengthAfterPathComputation(const SimTK::State& s,
-                               const Array<AbstractPathPoint*>& currentPath) const
-{
-    double length = getLength(s);
-//    setLength(s,length);
-    return( length );
-}
 
-void OpenSim::FunctionBasedPath::
-computeLengtheningSpeed(const SimTK::State& s) const
+void OpenSim::FunctionBasedPath::computeLengtheningSpeed(const SimTK::State& s) const
 {
     double lengtheningspeed = getLengtheningSpeed(s);
-    setLengtheningSpeed(s,lengtheningspeed);
+    setLengtheningSpeed(s, lengtheningspeed);
 }
 
-//------------------------------------------------------------------------------
-//                         GENERATE DECORATIONS
-//------------------------------------------------------------------------------
-// The GeometryPath takes care of drawing itself here, using information it
-// can extract from the supplied state, including position information and
-// color information that may have been calculated as late as Stage::Dynamics.
-// For example, muscles may want the color to reflect activation level and
-// other path-using components might want to use forces (tension). We will
-// ensure that the state has been realized to Stage::Dynamics before looking
-// at it. (It is only guaranteed to be at Stage::Position here.)
-void OpenSim::FunctionBasedPath::
-generateDecorations(bool fixed, const ModelDisplayHints& hints,
-                    const SimTK::State& state,
-                    SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const
+double OpenSim::FunctionBasedPath::calcLengthAfterPathComputation(
+        const SimTK::State& s,
+        const Array<AbstractPathPoint*>& currentPath) const
 {
-    std::cerr << "generateDecorations() called on a FunctionBasedPath";
-    std::cerr << "which has no implementation yet";
-    std::cerr << "call will be therefore be ignored" << std::endl;
-    // todo
+    return getLength(s);
 }
 
-
-//----------------------------------------------------------------------------
-//                          VIRTUAL METHODS EMPTY DEFINED
-//----------------------------------------------------------------------------
 double OpenSim::FunctionBasedPath::calcPathLengthChange(const SimTK::State& s,
                                                         const WrapObject& wo,
                                                         const WrapResult& wr,
                                                         const Array<AbstractPathPoint*>& path) const
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `calcPathLengthChange` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it isn't path-based). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
 
-void OpenSim::FunctionBasedPath::addPathWrap(WrapObject& aWrapObject)
+void OpenSim::FunctionBasedPath::getPointForceDirections(const SimTK::State& s,
+                                                         OpenSim::Array<PointForceDirection*> *rPFDs) const
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `getPointForceDirections` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it isn't path-based). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
 
-
-const Array<AbstractPathPoint*>& OpenSim::FunctionBasedPath::getCurrentPath( const SimTK::State& s) const
+const OpenSim::Array<OpenSim::AbstractPathPoint*>& OpenSim::FunctionBasedPath::getCurrentPath(const SimTK::State& s) const
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `getCurrentPath` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it does not contain a path). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
 
-AbstractPathPoint* OpenSim::FunctionBasedPath::addPathPoint(const SimTK::State& s, int index,
-                                                            const PhysicalFrame& frame)
+OpenSim::AbstractPathPoint* OpenSim::FunctionBasedPath::addPathPoint(
+        const SimTK::State& s,
+        int index,
+        const PhysicalFrame& frame)
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `addPathPoint` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it does not contain a path). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
 
-AbstractPathPoint* OpenSim::FunctionBasedPath::appendNewPathPoint(const std::string& proposedName,
-                                                                  const PhysicalFrame& frame,
-                                                                  const SimTK::Vec3& locationOnFrame)
+OpenSim::AbstractPathPoint* OpenSim::FunctionBasedPath::appendNewPathPoint(
+        const std::string& proposedName,
+        const PhysicalFrame& frame,
+        const SimTK::Vec3& locationOnFrame)
 {
-    std::cerr << "appendNewPathPoint called on a FunctionBasedPath";
-    std::cerr << "call will be ignored" << std::endl;
-//    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
-    return nullptr;
+    OPENSIM_THROW(Exception, "Tried to call `appendNewPathPoint` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it does not contain a path). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
 
 bool OpenSim::FunctionBasedPath::canDeletePathPoint(int index)
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `canDeletePathPoint` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it does not contain a path). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
 
 bool OpenSim::FunctionBasedPath::deletePathPoint(const SimTK::State& s,
                                                  int index)
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `deletePathPoint` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it does not contain a path). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
 
 bool OpenSim::FunctionBasedPath::replacePathPoint(const SimTK::State& s,
                                                   AbstractPathPoint* oldPathPoint,
                                                   AbstractPathPoint* newPathPoint)
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `replacePathPoint` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it does not contain a path). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
 
-
-void OpenSim::FunctionBasedPath::moveUpPathWrap(const SimTK::State& s,
-                                                int index)
+void OpenSim::FunctionBasedPath::addPathWrap(WrapObject& aWrapObject)
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
-}
-
-void OpenSim::FunctionBasedPath::moveDownPathWrap(const SimTK::State& s,
-                                                  int index)
-{
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `addPathWrap` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it does not contain wrapping objects). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
 
 void OpenSim::FunctionBasedPath::deletePathWrap(const SimTK::State& s,
                                                 int index)
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `deletePathWrap` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it does not contain wrapping objects). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
 
+void OpenSim::FunctionBasedPath::moveUpPathWrap(const SimTK::State& s,
+                                                int index)
+{
+    OPENSIM_THROW(Exception, "Tried to call `moveUpPathWrap` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it does not contain wrapping objects). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
+}
+
+void OpenSim::FunctionBasedPath::moveDownPathWrap(const SimTK::State& s,
+                                                  int index)
+{
+    OPENSIM_THROW(Exception, "Tried to call `moveDownPathWrap` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it does not contain wrapping objects). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
+}
 
 void OpenSim::FunctionBasedPath::applyWrapObjects(const SimTK::State& s,
                                                   Array<AbstractPathPoint*>& path ) const
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `applyWrapObjects` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it doesn't know how to apply wrap objects to a sequence of path points). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }
-
 
 void OpenSim::FunctionBasedPath::namePathPoints(int aStartingIndex)
 {
-    std::cerr << "namePathPoints(int index) called on a FunctionBasedPath";
-    std::cerr << "call will be ignored" << std::endl;
-//    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    static bool shownOnce = []() {
+        OpenSim::log_warn("Tried to call `namePathPoints` on a `FunctionBasedPath`. This function call will be ignored (`FunctionBasedPath`s do not contain path points)");
+        return true;
+    }();
+    (void)shownOnce;
 }
 
 void OpenSim::FunctionBasedPath::placeNewPathPoint(const SimTK::State& s,
@@ -1150,5 +788,5 @@ void OpenSim::FunctionBasedPath::placeNewPathPoint(const SimTK::State& s,
                                                    int index,
                                                    const PhysicalFrame& frame)
 {
-    OPENSIM_THROW(Exception,"this method is not allowed within FunctionBasedPath");
+    OPENSIM_THROW(Exception, "Tried to call `placeNwPathPoint` on a `FunctionBasedPath`. You cannot call this method on a `GeometryPath` that is a `FunctionBasedPath` (it has no path points). Either remove this function call or replace the `FunctionBasedPath` with a `PointBasedPath` in the model");
 }

--- a/OpenSim/Simulation/Model/FunctionBasedPath.cpp
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.cpp
@@ -507,7 +507,7 @@ static double Impl_GetPathLengthDerivative(OpenSim::FunctionBasedPath::Impl cons
     // compute value at current point
     double v1 = Impl_GetPathLength(impl, inputVals.data(), nCoords);
 
-    static constexpr double h = 0.0001;
+    static constexpr double h = 0.000001;
 
     // alter the input value for the to-be-derived coordinate *slightly* and recompute
     inputVals[coordIdx] += h;

--- a/OpenSim/Simulation/Model/FunctionBasedPath.h
+++ b/OpenSim/Simulation/Model/FunctionBasedPath.h
@@ -24,12 +24,14 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#include <OpenSim/Common/Array.h>
+#include <OpenSim/Simulation/Model/AbstractPathPoint.h>
 #include <OpenSim/Simulation/Model/GeometryPath.h>
+#include <OpenSim/Simulation/Model/FunctionBasedPathDiscretizationSet.h>
+#include <SimTKcommon/internal/ClonePtr.h>
+#include <SimTKcommon/internal/Vec.h>
 
-#include <iosfwd>
-#include <memory>
 #include <string>
-#include <utility>
 
 #ifdef SWIG
     #ifdef OSIMSIMULATION_API
@@ -40,9 +42,14 @@
 
 // forward declarations
 namespace OpenSim {
+class Component;
+class Coordinate;
 class Model;
 class PointBasedPath;
-class Coordinate;
+class PointForceDirection;
+class PhysicalFrame;
+class WrapObject;
+class WrapResult;
 }
 
 namespace SimTK {
@@ -50,7 +57,6 @@ class State;
 }
 
 namespace OpenSim {
-
 /**
  * An `OpenSim::GeometryPath` that computes its length/lengtheningSpeed by
  * interpolating a pre-computed Bezier curve.
@@ -67,10 +73,12 @@ namespace OpenSim {
  * because a curve's paramaterization depends on its place in the Model as
  * a whole.
  */
-class OSIMSIMULATION_API FunctionBasedPath : public GeometryPath {    
+class OSIMSIMULATION_API FunctionBasedPath : public GeometryPath {
     OpenSim_DECLARE_CONCRETE_OBJECT(FunctionBasedPath, GeometryPath);
 
-    OpenSim_DECLARE_PROPERTY(data_path, std::string, "Path to the associated data file for this path. Typically, the file contains interpolated data that the implementation uses to compute the path's length and lengthening speed at simulation-time");
+public:
+    OpenSim_DECLARE_UNNAMED_PROPERTY(FunctionBasedPathDiscretizationSet, "Discretizations that were used for each OpenSim::Coordinate that the path was fitted against");
+    OpenSim_DECLARE_LIST_PROPERTY(Evaluations, double, "The evaluated results of each *permutation* of discretizations. The FunctionBasedPathDiscretizationSet property describes how each OpenSim::Coordinate was discretized. These evaluations are the result of permuting through all possible combinations of discretizations. Effectively, this property contains a N-dimensional 'surface' of points, where each dimension of the surface is a Coordinate, and each dimension of each point is one of the evenly-spaced points in the discretization range [x_begin, x_range] for each dimension");
 
     struct Impl;
 private:
@@ -80,20 +88,8 @@ public:
     /**
      * Returns an in-memory representation of a FunctionBasedPath generated
      * by fitting curves against the supplied PointBasedPath.
-     *
-     * Does not set the 'data' member (it's an in-memory represenation). Saving
-     * the resulting FunctionBasedPath without setting 'data' will throw an
-     * exception.
      */
-    static FunctionBasedPath fromPointBasedPath(const Model& model,
-                                                const PointBasedPath& pbp);
-
-    /**
-     * Returns an FunctionBasedPath read from an associated data file
-     *
-     * The file must contain the content written by `printContent`
-     */
-    FunctionBasedPath fromDataFile(const std::string& path);
+    static FunctionBasedPath fromPointBasedPath(const Model& model, const PointBasedPath& pbp);
 
     FunctionBasedPath();
     FunctionBasedPath(const FunctionBasedPath&);
@@ -103,7 +99,7 @@ public:
     ~FunctionBasedPath() noexcept override;
 
     void extendFinalizeFromProperties() override;
-    void extendFinalizeConnections(Component &root) override;
+    void extendFinalizeConnections(Component& root) override;
 
     double getLength(const SimTK::State& s) const override;
     void setLength(const SimTK::State& s, double length) const override;
@@ -111,80 +107,72 @@ public:
     double getLengtheningSpeed(const SimTK::State& s) const override;
     void setLengtheningSpeed(const SimTK::State& s, double speed) const override;
 
-    const std::string& getDataPath() const { return get_data_path(); }
-    void setDataPath(const std::string& newPath) { upd_data_path() = newPath; }
+    double computeMomentArm(const SimTK::State& s, const Coordinate& aCoord) const override;
 
-    double computeMomentArm(const SimTK::State& s,
-                            const Coordinate& aCoord) const override;
-
-    void printContent(std::ostream& printFile) const;
-
-
-    // From GeometryPath refactoring
-public:
     void addInEquivalentForces(const SimTK::State& state,
                                const double& tension,
                                SimTK::Vector_<SimTK::SpatialVec>& bodyForces,
-                               SimTK::Vector& mobilityForces) const;
+                               SimTK::Vector& mobilityForces) const override;
 
-    void getPointForceDirections(const SimTK::State& s,
-            OpenSim::Array<PointForceDirection*> *rPFDs) const;
+    void generateDecorations(bool fixed,
+                             const ModelDisplayHints& hints,
+                             const SimTK::State& state,
+                             SimTK::Array_<SimTK::DecorativeGeometry>& appendToThis) const override;
 
 protected:
-    void computePath(const SimTK::State& s ) const;
-    void computeLengtheningSpeed(const SimTK::State& s) const;
+    void computePath(const SimTK::State& s ) const override;
+    void computeLengtheningSpeed(const SimTK::State& s) const override;
 
-    double calcLengthAfterPathComputation
-       (const SimTK::State& s, const Array<AbstractPathPoint*>& currentPath) const;
+    double calcLengthAfterPathComputation(const SimTK::State& s,
+                                          const Array<AbstractPathPoint*>& currentPath) const override;
 
-    void generateDecorations(
-                    bool                                        fixed,
-                    const ModelDisplayHints&                    hints,
-                    const SimTK::State&                         state,
-                    SimTK::Array_<SimTK::DecorativeGeometry>&   appendToThis) const
-                    override;
-
-
-
-
-
-    // related to pathpoints so has to be removed in release
-protected:
-    double calcPathLengthChange(const SimTK::State& s, const WrapObject& wo,
+    double calcPathLengthChange(const SimTK::State& s,
+                                const WrapObject& wo,
                                 const WrapResult& wr,
-                                const Array<AbstractPathPoint*>& path) const;
-
-public:
-    void addPathWrap(WrapObject& aWrapObject);
+                                const Array<AbstractPathPoint*>& path) const override;
 
 private:
-    const Array<AbstractPathPoint*>& getCurrentPath( const SimTK::State& s) const;
+    void getPointForceDirections(const SimTK::State& s,
+                                 OpenSim::Array<PointForceDirection*> *rPFDs) const override;
+
+    const Array<AbstractPathPoint*>& getCurrentPath(const SimTK::State& s) const override;
+
     AbstractPathPoint* addPathPoint(const SimTK::State& s,
                                     int index,
-                                    const PhysicalFrame& frame);
+                                    const PhysicalFrame& frame) override;
+
     AbstractPathPoint* appendNewPathPoint(const std::string& proposedName,
                                           const PhysicalFrame& frame,
-                                          const SimTK::Vec3& locationOnFrame);
-    bool canDeletePathPoint(int index);
-    bool deletePathPoint(const SimTK::State& s,
-                         int index);
+                                          const SimTK::Vec3& locationOnFrame) override;
+
+    bool canDeletePathPoint(int index) override;
+
+    bool deletePathPoint(const SimTK::State& s, int index) override;
+
     bool replacePathPoint(const SimTK::State& s,
                           AbstractPathPoint* oldPathPoint,
-                          AbstractPathPoint* newPathPoint);
+                          AbstractPathPoint* newPathPoint) override;
+
+
+    void addPathWrap(WrapObject& aWrapObject) override;
+
+    void deletePathWrap(const SimTK::State& s, int index) override;
 
     void moveUpPathWrap(const SimTK::State& s,
-                        int index);
+                        int index) override;
+
     void moveDownPathWrap(const SimTK::State& s,
-                          int index);
-    void deletePathWrap(const SimTK::State& s,
-                        int index);
+                          int index) override;
 
     void applyWrapObjects(const SimTK::State& s,
-                          Array<AbstractPathPoint*>& path) const;
+                          Array<AbstractPathPoint*>& path) const override;
 
-    void namePathPoints(int aStartingIndex);
-    void placeNewPathPoint(const SimTK::State& s, SimTK::Vec3& aOffset,
-                           int index, const PhysicalFrame& frame);
+    void namePathPoints(int aStartingIndex) override;
+
+    void placeNewPathPoint(const SimTK::State& s,
+                           SimTK::Vec3& aOffset,
+                           int index,
+                           const PhysicalFrame& frame) override;
 };
 }
 

--- a/OpenSim/Simulation/Model/FunctionBasedPathDiscretization.h
+++ b/OpenSim/Simulation/Model/FunctionBasedPathDiscretization.h
@@ -38,6 +38,13 @@ namespace OpenSim {
         OpenSim_DECLARE_PROPERTY(x_begin, double, "The lowest OpenSim::Coordinate value that was used for discretization");
         OpenSim_DECLARE_PROPERTY(x_end, double, "The highest OpenSim:::Coordinate value that was used for discretization");
         OpenSim_DECLARE_PROPERTY(num_points, int, "The number of evenly-spaced OpenSim::Coordinate values between [x_begin, x_end] (inclusive) that were used for discretization of the OpenSim::Coordinate. E.g. [x_begin, 1*(x_begin+((x_end-x_begin)/3)), 2*(x_begin+((x_end-x_begin)/3)), x_end]");
+
+        FunctionBasedPathDiscretization() {
+            constructProperty_coordinate_abspath("");
+            constructProperty_x_begin(0.0);
+            constructProperty_x_end(0.0);
+            constructProperty_num_points(0);
+        }
     };
 }
 

--- a/OpenSim/Simulation/Model/FunctionBasedPathDiscretization.h
+++ b/OpenSim/Simulation/Model/FunctionBasedPathDiscretization.h
@@ -1,0 +1,44 @@
+#ifndef FUNCTIONBASEDPATHDISCRETIZATION_H
+#define FUNCTIONBASEDPATHDISCRETIZATION_H
+
+/* -------------------------------------------------------------------------- *
+ *              OpenSim: FunctionBasedPathDiscretization.h                    *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2021 TU Delft and the Authors                           *
+ * Author(s): Joris Verhagen                                                  *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include <OpenSim/Common/Component.h>
+#include <OpenSim/Simulation/osimSimulationDLL.h>
+
+#include <string>
+
+namespace OpenSim {
+    class OSIMSIMULATION_API FunctionBasedPathDiscretization : public Component {
+        OpenSim_DECLARE_CONCRETE_OBJECT(FunctionBasedPathDiscretization, Component);
+
+    public:
+        OpenSim_DECLARE_PROPERTY(coordinate_abspath, std::string, "The absolute path, in the model, to the OpenSim::Coordinate that this discretization was produced from");
+        OpenSim_DECLARE_PROPERTY(x_begin, double, "The lowest OpenSim::Coordinate value that was used for discretization");
+        OpenSim_DECLARE_PROPERTY(x_end, double, "The highest OpenSim:::Coordinate value that was used for discretization");
+        OpenSim_DECLARE_PROPERTY(num_points, int, "The number of evenly-spaced OpenSim::Coordinate values between [x_begin, x_end] (inclusive) that were used for discretization of the OpenSim::Coordinate. E.g. [x_begin, 1*(x_begin+((x_end-x_begin)/3)), 2*(x_begin+((x_end-x_begin)/3)), x_end]");
+    };
+}
+
+#endif // FUNCTIONBASEDPATHDISCRETIZATION_H

--- a/OpenSim/Simulation/Model/FunctionBasedPathDiscretizationSet.h
+++ b/OpenSim/Simulation/Model/FunctionBasedPathDiscretizationSet.h
@@ -1,0 +1,39 @@
+#ifndef FUNCTIONBASEDPATHDISCRETIZATIONSET_H
+#define FUNCTIONBASEDPATHDISCRETIZATIONSET_H
+
+/* -------------------------------------------------------------------------- *
+ *            OpenSim: FunctionBasedPathDiscretizationSet.h                   *
+ * -------------------------------------------------------------------------- *
+ * The OpenSim API is a toolkit for musculoskeletal modeling and simulation.  *
+ * See http://opensim.stanford.edu and the NOTICE file for more information.  *
+ * OpenSim is developed at Stanford University and supported by the US        *
+ * National Institutes of Health (U54 GM072970, R24 HD065690) and by DARPA    *
+ * through the Warrior Web program.                                           *
+ *                                                                            *
+ * Copyright (c) 2005-2021 TU Delft and the Authors                           *
+ * Author(s): Joris Verhagen                                                  *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include <OpenSim/Simulation/osimSimulationDLL.h>
+#include <OpenSim/Common/Set.h>
+#include <OpenSim/Simulation/Model/FunctionBasedPathDiscretization.h>
+
+namespace OpenSim {
+
+class OSIMSIMULATION_API FunctionBasedPathDiscretizationSet : public Set<FunctionBasedPathDiscretization> {
+    OpenSim_DECLARE_CONCRETE_OBJECT(FunctionBasedPathDiscretizationSet, Set<FunctionBasedPathDiscretization>);
+};
+
+}
+
+#endif // FUNCTIONBASEDPATHDISCRETIZATIONSET_H

--- a/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
+++ b/OpenSim/Simulation/RegisterTypes_osimSimulation.cpp
@@ -62,6 +62,8 @@
 
 #include "Model/GeometryPath.h"
 #include "Model/PointBasedPath.h"
+#include "Model/FunctionBasedPathDiscretization.h"
+#include "Model/FunctionBasedPathDiscretizationSet.h"
 #include "Model/FunctionBasedPath.h"
 
 #include "Model/PrescribedForce.h"
@@ -193,8 +195,9 @@ OSIMSIMULATION_API void RegisterTypes_osimSimulation()
     Object::registerType( FrameGeometry());
     Object::registerType( Arrow());
 
-//    Object::registerType( GeometryPath());
     Object::registerType( OpenSim::PointBasedPath());
+    Object::registerType( OpenSim::FunctionBasedPathDiscretization());
+    Object::registerType( OpenSim::FunctionBasedPathDiscretizationSet());
     Object::registerType( OpenSim::FunctionBasedPath());
 
     Object::registerType( ControlSet() );

--- a/OpenSim/Simulation/osimSimulation.h
+++ b/OpenSim/Simulation/osimSimulation.h
@@ -55,6 +55,8 @@
 
 #include "Model/GeometryPath.h"
 #include "Model/PointBasedPath.h"
+#include "Model/FunctionBasedPathDiscretization.h"
+#include "Model/FunctionBasedPathDiscretizationSet.h"
 #include "Model/FunctionBasedPath.h"
 
 #include "Model/PrescribedForce.h"

--- a/OpenSim/Tools/FunctionBasedPathConversionTool.cpp
+++ b/OpenSim/Tools/FunctionBasedPathConversionTool.cpp
@@ -10,150 +10,135 @@
 
 using namespace OpenSim;
 
-FunctionBasedPathConversionTool::~FunctionBasedPathConversionTool()
+OpenSim::FunctionBasedPathConversionTool::FunctionBasedPathConversionTool() :
+    _modelPath{},
+    _newModelName{},
+    _verbose{false}
 {
-//    delete &_modelPath;
-//    delete &_newModelName;
 }
 
-FunctionBasedPathConversionTool::FunctionBasedPathConversionTool()
-    : _modelPath(""), _newModelName("")
-{
+OpenSim::FunctionBasedPathConversionTool::FunctionBasedPathConversionTool(
+        const std::string& modelPath,
+        const std::string& newModelName) :
 
+    _modelPath{modelPath},
+    _newModelName{newModelName},
+    _verbose{false}
+{
 }
 
-FunctionBasedPathConversionTool::FunctionBasedPathConversionTool(
-        const std::string modelPath, const std::string newModelName)
-    : _modelPath(modelPath), _newModelName(newModelName)
+const std::string& OpenSim::FunctionBasedPathConversionTool::getModelPath() const
 {
-
+     return _modelPath;
 }
 
-bool FunctionBasedPathConversionTool::run(){
-    try{
-        Model sourceModel{_modelPath};
-        Model outputModel{sourceModel};
+void OpenSim::FunctionBasedPathConversionTool::setModelPath(const std::string& modelPath)
+{
+    _modelPath = modelPath;
+}
 
-        sourceModel.finalizeConnections();
-        sourceModel.finalizeFromProperties();
-        sourceModel.initSystem();
+const std::string& OpenSim::FunctionBasedPathConversionTool::getNewModelName() const
+{
+    return _newModelName;
+}
 
-        outputModel.finalizeConnections();
-        outputModel.finalizeFromProperties();
+void OpenSim::FunctionBasedPathConversionTool::setNewModelName(const std::string& newModelName)
+{
+    _newModelName = newModelName;
+}
 
-        bool verbose = false;
-        if (verbose) {
-            sourceModel.printSubcomponentInfo();
+bool OpenSim::FunctionBasedPathConversionTool::run()
+{
+    Model sourceModel{_modelPath};
+    sourceModel.finalizeConnections();
+    sourceModel.finalizeFromProperties();
+    sourceModel.initSystem();
+
+    Model outputModel{sourceModel};
+    outputModel.finalizeConnections();
+    outputModel.finalizeFromProperties();
+
+    // print source model structure when runnning in verbose mode
+    if (_verbose) {
+        sourceModel.printSubcomponentInfo();
+    }
+
+    // struct that holds how a PBP in the source maps onto an actuator in the
+    // destination
+    struct PBPtoActuatorMapping final {
+        PointBasedPath& sourcePBP;
+        PathActuator& outputActuator;
+
+        PBPtoActuatorMapping(PointBasedPath& sourcePBP_,
+                             PathActuator& outputActuator_) :
+            sourcePBP{sourcePBP_},
+            outputActuator{outputActuator_} {
+        }
+    };
+
+    // find PBPs in the source and figure out how they map onto `PathActuator`s
+    // in the destination
+    //
+    // (this is because `PathActuator`s are the "owners" of `GeometryPath`s in
+    //  most models)
+    std::vector<PBPtoActuatorMapping> mappings;
+    for (PathActuator& pa : sourceModel.updComponentList<PathActuator>()) {
+
+        PointBasedPath* pbp = dynamic_cast<PointBasedPath*>(&pa.updGeometryPath());
+
+        // if the actuator doesn't use a PBP, ignore it
+        if (!pbp) {
+            continue;
         }
 
-        // struct that holds how a PBP in the source maps onto an actuator in the
-        // destination
-        struct PBPtoActuatorMapping final {
-            PointBasedPath& sourcePBP;
-            PathActuator& outputActuator;
+        // otherwise, find the equivalent path in the destination
+        Component* c = const_cast<Component*>(outputModel.findComponent(pa.getAbsolutePath()));
 
-            PBPtoActuatorMapping(PointBasedPath& sourcePBP_,
-                                 PathActuator& outputActuator_) :
-                sourcePBP{sourcePBP_},
-                outputActuator{outputActuator_} {
-            }
-        };
-
-        // find PBPs in the source and figure out how they map onto `PathActuator`s
-        // in the destination
-        //
-        // (this is because `PathActuator`s are the "owners" of `GeometryPath`s in
-        //  most models)
-        std::vector<PBPtoActuatorMapping> mappings;
-        for (auto& pa : sourceModel.updComponentList<PathActuator>()) {
-
-            PointBasedPath* pbp = dynamic_cast<PointBasedPath*>(&pa.updGeometryPath());
-
-            // if the actuator doesn't use a PBP, ignore it
-            if (!pbp) {
-                continue;
-            }
-
-            // otherwise, find the equivalent path in the destination
-            Component* c = const_cast<Component*>(outputModel.findComponent(pa.getAbsolutePath()));
-
-            if (!c) {
-                std::stringstream err;
-                err << "could not find '" << pa.getAbsolutePathString() << "' in the output model: this is a programming error";
-                throw std::runtime_error{move(err).str()};
-            }
-
-            PathActuator* paDest = dynamic_cast<PathActuator*>(c);
-
-            if (!paDest) {
-                std::stringstream err;
-                err << "the component '" << pa.getAbsolutePathString() << "' has a class of '" << pa.getConcreteClassName() << "' in the source model but a class of '" << c->getConcreteClassName() << "' in the destination model: this shouldn't happen";
-                throw std::runtime_error{move(err).str()};
-            }
-
-            mappings.emplace_back(*pbp, *paDest);
+        if (!c) {
+            std::stringstream err;
+            err << "could not find '" << pa.getAbsolutePathString() << "' in the output model: this is a programming error";
+            throw std::runtime_error{move(err).str()};
         }
 
-        // for each `PathActuator` that uses a PBP, create an equivalent
-        // `FunctionBasedPath` (FBP) by fitting a function against the PBP and
-        // replace the PBP owned by the destination's `PathActuator` with the FBP
-        int i = 1;
-        std::string newModelNameLocal = _newModelName;
-        for (const auto& mapping : mappings) {
-            // create an FBP in-memory
-            FunctionBasedPath fbp = FunctionBasedPath::fromPointBasedPath(sourceModel, mapping.sourcePBP);
+        PathActuator* paDest = dynamic_cast<PathActuator*>(c);
 
-            // write the FBP's data to the filesystem
-            std::string dataFilename = [newModelNameLocal, &i]() {
-                std::stringstream ss;
-                ss << newModelNameLocal << "_DATA_" << i <<  ".txt";
-                return move(ss).str();
-            }();
+        if (!paDest) {
+            std::stringstream err;
+            err << "the component '" << pa.getAbsolutePathString() << "' has a class of '" << pa.getConcreteClassName() << "' in the source model but a class of '" << c->getConcreteClassName() << "' in the destination model: this shouldn't happen";
+            throw std::runtime_error{move(err).str()};
+        }
 
-            std::ofstream dataFile{dataFilename};
+        mappings.emplace_back(*pbp, *paDest);
+    }
 
-            if (!dataFile) {
-                std::stringstream msg;
-                msg << "error: could not open a `FunctionBasedPath`'s data file at: " << dataFilename;
-                throw std::runtime_error{move(msg).str()};
-            }
+    // for each `PathActuator` that uses a PBP, create an equivalent
+    // `FunctionBasedPath` (FBP) by fitting a function against the PBP and
+    // replace the PBP owned by the destination's `PathActuator` with the FBP
+    for (const PBPtoActuatorMapping& mapping : mappings) {
+        // create an FBP in-memory
+        FunctionBasedPath::FittingParams p;
+        std::unique_ptr<FunctionBasedPath> maybeFbp = FunctionBasedPath::fromPointBasedPath(sourceModel, mapping.sourcePBP, p);
 
-            fbp.printContent(dataFile);
-
-            if (!dataFile) {
-                std::stringstream msg;
-                msg << "error: error occurred after writing `FunctionBasedPath`s data to" << dataFilename;
-                throw std::runtime_error{move(msg).str()};
-            }
-
-            // update the FBP to refer to the data file
-            fbp.setDataPath(dataFilename);
-
+        if (maybeFbp) {
             // assign the FBP over the destination's PBP
-            mapping.outputActuator.updProperty_GeometryPath().setValue(fbp);
-
-            ++i;
+            mapping.outputActuator.updProperty_GeometryPath().setValue(*maybeFbp);
         }
+    }
 
-        // the output model is now the same as the source model, but each PBP in
-        // its `PathActuator`s has been replaced with an FBP. Perform any final
-        // model-level fixups and save the output model.
+    // the output model is now the same as the source model, but each PBP in
+    // its `PathActuator`s has been replaced with an FBP. Perform any final
+    // model-level fixups and save the output model.
+    outputModel.finalizeFromProperties();
+    outputModel.finalizeConnections();
+    outputModel.initSystem();
+    outputModel.print(std::string{_newModelName} + ".osim");
 
-        outputModel.finalizeFromProperties();
-        outputModel.finalizeConnections();
-        outputModel.initSystem();
-        outputModel.print(std::string{_newModelName} + ".osim");
-
-        if (verbose) {
-            std::cerr << "--- interpolation complete ---\n\n"
-                      << "model before:\n";
-            sourceModel.printSubcomponentInfo();
-            std::cerr << "\nmodel after:\n";
-            outputModel.printSubcomponentInfo();
-        }
-    } catch(const std::exception& x) {
-        log_error("Exception in FunctionBasedPathConversionTool: run", x.what());
-        return false;
+    if (_verbose) {
+        std::cerr << "--- interpolation complete ---\n\n"
+                  << "model before:\n";
+        sourceModel.printSubcomponentInfo();
+        std::cerr << "\nmodel after:\n";
+        outputModel.printSubcomponentInfo();
     }
 
     return true;

--- a/OpenSim/Tools/FunctionBasedPathConversionTool.h
+++ b/OpenSim/Tools/FunctionBasedPathConversionTool.h
@@ -50,6 +50,7 @@ class OSIMTOOLS_API FunctionBasedPathConversionTool: public AbstractTool {
 private:
     std::string _modelPath;
     std::string _newModelName;
+    FunctionBasedPath::FittingParams _params;
     bool _verbose;
 
 public:
@@ -61,6 +62,12 @@ public:
 
     const std::string& getNewModelName() const;
     void setNewModelName(const std::string&);
+
+    const FunctionBasedPath::FittingParams& getFittingParams() const;
+    void setFittingParams(const FunctionBasedPath::FittingParams&);
+
+    bool getVerbose() const;
+    void setVerbose(bool);
 
     bool run() override SWIG_DECLARE_EXCEPTION;
 };

--- a/OpenSim/Tools/FunctionBasedPathConversionTool.h
+++ b/OpenSim/Tools/FunctionBasedPathConversionTool.h
@@ -44,58 +44,27 @@ namespace OpenSim {
  * @version 1.0
  */
 class OSIMTOOLS_API FunctionBasedPathConversionTool: public AbstractTool {
-OpenSim_DECLARE_CONCRETE_OBJECT(FunctionBasedPathConversionTool, AbstractTool);
 
-//=============================================================================
-// MEMBER VARIABLES
-//=============================================================================
-protected:
+    OpenSim_DECLARE_CONCRETE_OBJECT(FunctionBasedPathConversionTool, AbstractTool);
+
+private:
     std::string _modelPath;
     std::string _newModelName;
+    bool _verbose;
 
-//=============================================================================
-// METHODS
-//=============================================================================
-    //--------------------------------------------------------------------------
-    // CONSTRUCTION
-    //--------------------------------------------------------------------------
 public:
-    virtual ~FunctionBasedPathConversionTool();
     FunctionBasedPathConversionTool();
-    FunctionBasedPathConversionTool(const std::string modelPath, const std::string newModelName);
+    FunctionBasedPathConversionTool(const std::string& modelPath, const std::string& newModelName);
 
-//    void generateModelAndPrint();
+    const std::string& getModelPath() const;
+    void setModelPath(const std::string&);
 
-    //--------------------------------------------------------------------------
-    // OPERATORS
-    //--------------------------------------------------------------------------
-public:
-//#ifndef SWIG
-//    FunctionBasedPathConversionTool&
-//        operator=(const FunctionBasedPathConversionTool &aFunctionBasedPathConversionTool);
-//#endif
-//    void updateFromXMLNode(SimTK::Xml::Element& aNode, int versionNumber=-1) override;
+    const std::string& getNewModelName() const;
+    void setNewModelName(const std::string&);
 
-    //--------------------------------------------------------------------------
-    // GET AND SET
-    //--------------------------------------------------------------------------
-    void setModelPath(const std::string modelPath) {_modelPath = modelPath;}
-    void setNewModelName(const std::string newModelName) {_newModelName = newModelName;}
-    std::string getModelPath() {return _modelPath;}
-    std::string getNewModelName() {return _newModelName;}
-
-    //--------------------------------------------------------------------------
-    // INTERFACE
-    //--------------------------------------------------------------------------
     bool run() override SWIG_DECLARE_EXCEPTION;
-
-//=============================================================================
-};  // END of class FunctionBasedPathConversionTool
-
-}; //namespace
-//=============================================================================
-//=============================================================================
-
+};
+}
 #endif // _FunctionBasedPathConversionTool_h__
 
 


### PR DESCRIPTION
This is still a WIP, but hopefully will clean up + accelerate the implementation. Changes:

- Moved the evaluations into the `.osim` file
  - The `osim` file now contains the evaluations, rather than some external file
  - This simplifies the `finalizeFromProperties` and `finalizeConnections` phases of the model, because they used to rely on loading external files, which can fail if (e.g.) the model is copied in-memory (and, therefore, has no backing file from which the parent directory can be computed) or if the model file is opened by a GUI running in a different working directory (which requires careful handling of the current working directory during the finalization phase, which causes other bugs)
  - This also simplifies the command-line tool, because it now has a 1:1 relationship between input and output (osim goes in, osim goes out - no other files)
  - This does mean that FBP-based model files can become very large, but (imho) this is outweighed by the advantages of having everything in one file
  - The data looks something like:
```xml
<FunctionBasedPath name="functionbasedpath">
    <!-- other props -->
    <FunctionBasedPathDiscretizationSet>
        <objects>
            <FunctionBasedPathDiscretization name="functionbasedpathdiscretization">
                <!--The absolute path, in the model, to the OpenSim::Coordinate that this discretization was produced from-->
                <coordinate_abspath>/jointset/r_shoulder/r_shoulder_elev</coordinate_abspath>
                <!--The lowest OpenSim::Coordinate value that was used for discretization-->
                <x_begin>-1.6231562043547265</x_begin>
                <!--The highest OpenSim:::Coordinate value that was used for discretization-->
                <x_end>1.6755160819145563</x_end>
                <!--The number of evenly-spaced OpenSim::Coordinate values between [x_begin, x_end] (inclusive) that were used for discretization of the OpenSim::Coordinate. E.g. [x_begin, 1*(x_begin+((x_end-x_begin)/3)), 2*(x_begin+((x_end-x_begin)/3)), x_end]-->
                <num_points>64</num_points>
            </FunctionBasedPathDiscretization>
        </objects>
    </FunctionBasedPathDiscretizationSet>
    <Evaluations>
        0.27785555660465677 0.27672518770854371 0.2755762685216484 <!--- a lot more numbers -->
    </Evaluations>
</FunctionBasedPath>
```

- Added a variety of comments that try to explain each step of the process
    - This includes restructuring the implementation file to use standalone functions over simple datatypes
- Methods that used to warn on each call (e.g. `generateDecorations`) now warn once per application boot
    - This is to prevent the situation where a GUI calling `generateDecorations` repeatably would have its log spammed with the same warning message
- Externalized all path fitting parameters into a caller-provided `FunctionBasedPath::FittingParams` struct
    - This is so that external users can tweak with the fitting params without having to recompile the codebase. It enables performing experiments on different gridsizes, probing steps, maximum coordinates, etc. with scripts.
    - The main utility of this is that it lets us performance-tweak the PBP-to-FBP step
    - Here's the struct:

```c++
  struct FittingParams final {

      // maximum coords that can affect the given PointBasedPath
      //
      // if this is higher, more paths may be eligible for
      // PointBasedPath --> FunctionBasedPath conversion, because some paths may be
      // affected by more coordinates than other paths. However, be careful. Increasing
      // this also *significantly* increases the memory usage of the function-based fit
      //
      // must be 0 < v <= 16, or -1 to mean "use a sensible default"
      int maxCoordsThatCanAffectPath;

      // number of discretization steps to use for each coordinate during the "probing
      // phase"
      //
      // in the "probing phase", each coordinate is set to this number of evenly-spaced
      // values in the range [getRangeMin()..getRangeMax()] (inclusive) to see if changing
      // that coordinate has any affect on the path. The higher this value is, the longer
      // the probing phase takes, but the higher chance it has of spotting a pertubation
      //
      // must be >0, or -1 to mean "use a sensible default"
      int numProbingDiscretizations;

      // minimum amount that the moment arm of the path must change by during the "probing phase"
      // for the coorinate to be classified as affecting the path
      //
      // must be >0, or <0 to mean "use a sensible default"
      double minProbingMomentArmChange;

      // the number of discretization steps for each coordinate that passes the "probing phase" and,
      // therefore, is deemed to affect the input (point-based) path
      //
      // this is effectively "grid granulaity". More discretizations == better fit, but it can increase
      // the memory usage of the fit significantly. Assume the path is parameterized as an n-dimensional
      // surface. E.g. if you discretize 10 points over 10 dimensions then you may end up with
      // 10^10 datapoints (ouch).
      //
      // must be >0, or -1 to mean "use a sensible default"
      int numDiscretizationStepsPerDimension;

      FittingParams();
  };
```
- Changed signature of `FunctionBasedPath::fromPointBasedPath` to return a `std::unique_ptr<FunctionBasedPath>` rather than a `FunctionBasedPath` (and also, so that it takes the `FittingParams`, above)

  - This allows the function to fail to fit the path and return `nullptr`, which the caller can handle as "can't fit"
  - This allows the user to use `FittingParams` to limit how "far" the fitting implementation should go. E.g. if it's known that some muscles are affected by *many* coordinates, it's probably best to leave it as a `PointBasedPath` (this is likely to be the case for larger models)

- Refactored the algorithm to maximize performance + readability:
  - Functions renamed to reflect intent (e.g. `getInterpDer` --> `Impl_GetPathLengthDerivative`, `getInterp` --> `Impl_GetPathLength`)
  - Added a variety of comments that try to explain each step of the algorithm, with appropriate links
  - Renamed a variety of variables to reflect intent (e.g. `dS` --> `discretizations`, `n` --> `closestDiscretizationSteps`)
  - Removed all runtime memory allocations and replaced them with static arrays that have an upper bound (`g_MaxCoordsThatCanBeInterpolated`)
  - Removed most of the auxiliary datastructures that were held in `Interpolation`. Many of them can be computed on-the-fly by the CPU (e.g. `gridsize == (discretization.end-discretization.start)/(discretization.steps-1)). Most of these datastructures are now created + populated at runtime in stack-based arrays that have no allocation overhead
  - Replaced runtime data lookups with closed-form mathematical equivalents. E.g. instead of finding the closest discretization by iterating over a collection of discretization steps, the implementation computes the whole number part of `v = begin + n*stepSize` (solved for `n`)
  - Replaced multiply-add accumulations (e.g. `acc += x*y`) inside loops with `std::fma` (e.g. `acc = std::fma(x, y, acc);`). This reduces error propagation when accumulating small values onto larger values in a loop (e.g. `z += beta*v`)
  - Micro-optimized the implementation based on feedback from `perf` and `valgrind`. This mostly involved doing things like switching `pow` calls for in-source equivalents (e.g. `pow(frac, 2)` --> `frac*frac`). Some compilers do not optimize `pow` (yet)